### PR TITLE
Fix orthographic camera scaling (point-size) and loading issues

### DIFF
--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -8,6 +8,7 @@ import {
 	Material,
 	NearestFilter,
 	NoBlending,
+	OrthographicCamera,
 	PerspectiveCamera,
 	RawShaderMaterial,
 	Scene,
@@ -81,6 +82,9 @@ export interface IPointCloudMaterialUniforms {
   rgbGamma: IUniform<number>;
   screenHeight: IUniform<number>;
   screenWidth: IUniform<number>;
+  orthoHeight: IUniform<number>;
+  orthoWidth: IUniform<number>;
+  useOrthographicCamera: IUniform<boolean>;
   size: IUniform<number>;
   spacing: IUniform<number>;
   toModel: IUniform<number[]>;
@@ -213,6 +217,9 @@ export class PointCloudMaterial extends RawShaderMaterial
 		rgbGamma: makeUniform('f', DEFAULT_RGB_GAMMA),
 		screenHeight: makeUniform('f', 1.0),
 		screenWidth: makeUniform('f', 1.0),
+		useOrthographicCamera: makeUniform('b', false),
+		orthoHeight: makeUniform('f', 1.0),
+		orthoWidth: makeUniform('f', 1.0),
 		size: makeUniform('f', 1),
 		spacing: makeUniform('f', 1.0),
 		toModel: makeUniform('Matrix4f', []),
@@ -270,6 +277,12 @@ export class PointCloudMaterial extends RawShaderMaterial
   @uniform('screenHeight') screenHeight!: number;
 
   @uniform('screenWidth') screenWidth!: number;
+
+  @uniform('orthoWidth') orthoWidth!: number;
+
+  @uniform('orthoHeight') orthoHeight!: number;
+
+  @uniform('useOrthographicCamera') useOrthographicCamera!: boolean;
 
   @uniform('size') size!: number;
 
@@ -668,10 +681,15 @@ export class PointCloudMaterial extends RawShaderMaterial
 
   	if (camera.type === PERSPECTIVE_CAMERA) 
   	{
+  		this.useOrthographicCamera = false;
   		this.fov = (camera as PerspectiveCamera).fov * (Math.PI / 180);
   	}
-  	else 
+  	else // ORTHOGRAPHIC
   	{
+   		const orthoCamera = (camera as OrthographicCamera);
+  		this.useOrthographicCamera = true;
+  		this.orthoWidth = (orthoCamera.right - orthoCamera.left) / orthoCamera.zoom;
+  		this.orthoHeight = (orthoCamera.top - orthoCamera.bottom) / orthoCamera.zoom;
   		this.fov = Math.PI / 2; // will result in slope = 1 in the shader
   	}
   	const renderTarget = renderer.getRenderTarget();

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -281,6 +281,8 @@ export class Potree implements IPotree
 			const radius = sphere.radius;
 
 			let projectionFactor = 0.0;
+			let weight: number;
+			let screenPixelRadius: number;
 
 			if (camera.type === PERSPECTIVE_CAMERA) 
 			{
@@ -288,14 +290,16 @@ export class Potree implements IPotree
 				const fov = perspective.fov * Math.PI / 180.0;
 				const slope = Math.tan(fov / 2.0);
 				projectionFactor = halfHeight / (slope * distance);
+				screenPixelRadius = radius * projectionFactor;
+				weight = distance < radius ? Number.MAX_VALUE : screenPixelRadius + 1 / distance;
 			}
 			else 
 			{
 				const orthographic = camera as OrthographicCamera;
-				projectionFactor = 2 * halfHeight / (orthographic.top - orthographic.bottom);
+				projectionFactor = 2 * halfHeight / (orthographic.top - orthographic.bottom) * orthographic.zoom;
+				screenPixelRadius = radius * projectionFactor;
+				weight = screenPixelRadius;
 			}
-
-			const screenPixelRadius = radius * projectionFactor;
 
 			// Don't add the node if it'll be too small on the screen.
 			if (screenPixelRadius < pointCloud.minNodePixelSize) 
@@ -304,8 +308,6 @@ export class Potree implements IPotree
 			}
 
 			// Nodes which are larger will have priority in loading/displaying.
-			const weight = distance < radius ? Number.MAX_VALUE : screenPixelRadius + 1 / distance;
-
 			priorityQueue.push(new QueueItem(queueItem.pointCloudIndex, weight, child, node));
 		}
 	}


### PR DESCRIPTION
This fixes an issue with wrong scaling of the orthographic camera in the shader.
And with the loading heuristics as well.

It's mostly adapted from the original potree.