### PR TITLE
Refactor FEATURES to be a function

### DIFF
--- a/source/features.ts
+++ b/source/features.ts
@@ -1,4 +1,4 @@
-let gl: WebGLRenderingContext | null = null;
+let context: WebGLRenderingContext | null = null;
 
 export const getFeatures = () => ({
 	SHADER_INTERPOLATION: hasExtension('EXT_frag_depth') && hasMinVaryingVectors(8),
@@ -9,27 +9,30 @@ export const getFeatures = () => ({
 });
 
 function renderer() {
-	if (gl) return gl; // cache
-	if (typeof document === 'undefined') return false; // server side
+	if (context) return context; // cache
+	if (typeof document === 'undefined') return null; // server side
 	// create a new context
 	const canvas = document.createElement('canvas');
-	gl = canvas.getContext('webgl');
-	return gl;
+	context = canvas.getContext('webgl');
+	return context;
 }
 
 function hasExtension(ext: string)
 {
-	return renderer() !== null && Boolean(gl.getExtension(ext));
+	const gl = renderer();
+	return gl !== null && Boolean(gl.getExtension(ext));
 }
 
 function hasMinVaryingVectors(value: number)
 {
-	return renderer() !== null && gl.getParameter(gl.MAX_VARYING_VECTORS) >= value;
+	const gl = renderer();
+	return gl !== null && gl.getParameter(gl.MAX_VARYING_VECTORS) >= value;
 }
 
 function getPrecision()
 {
-	if (renderer() === null)
+	const gl = renderer();
+	if (gl === null)
 	{
 		return '';
 	}

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -18,7 +18,7 @@ import {
 	MAX_NUM_NODES_LOADING,
 	PERSPECTIVE_CAMERA
 } from './constants';
-import {FEATURES} from './features';
+import {getFeatures} from './features';
 import {GetUrlFn, loadPOC} from './loading';
 import {ClipMode} from './materials';
 import {PointCloudOctree} from './point-cloud-octree';
@@ -52,7 +52,10 @@ export class Potree implements IPotree
 
 	maxNumNodesLoading: number = MAX_NUM_NODES_LOADING;
 
-	features = FEATURES;
+	get features() 
+	{
+		return getFeatures();
+	}
 
 	lru = new LRU(this._pointBudget);
 


### PR DESCRIPTION
This pull request refactors the `FEATURES` object in the code to be a function called `getFeatures()`. This change ensures that the document doesn't need to be accessed in the root of the file, making sure Potree doesn't break when used in a server-side rendering environment.

This change preserves the usage of the `features` property in the Potree class by making it a get property that calls the `getFeatures` function