### PR TITLE
move three package from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
 		"three": ">0.125.0"
 	},
 	"dependencies": {
-		"three": "^0.154.0",
 		"brotli": "1.3.3"
 	},
 	"devDependencies": {
@@ -48,6 +47,7 @@
 		"html-webpack-plugin": "5.5.0",
 		"raw-loader": "4.0.2",
 		"style-loader": "3.3.1",
+		"three": "^0.154.0",
 		"ts-loader": "9.5.1",
 		"typescript": "5.5.4",
 		"webpack": "5.94.0",


### PR DESCRIPTION
Move `three` package from dependencies to devDependencies.
(Note: The `three` package was moved from devDependencies to dependencies in this commit: https://github.com/tentone/potree-core/commit/22240ed43c700251d39cb6acf98de1639528ea54)

# Problem
Currently, the `three` package is specified as `"three": "^0.154.0"` in `dependencies`. This causes the following issues:

1. Users who `npm install potree-core` are restricted to using three version 0.154.x
2. When users have a different version of `three` in their project, multiple three instances get installed:
```
> npm ls three
my-app@0.0.1 C:\work\my-app
├┬ potree-core@2.0.10
│└── three@0.154.0
└── three@0.172.0
```
3. Multiple `three` instances cause the following browser error, preventing proper functionality:
`WARNING: Multiple instances of Three.js being imported.`

# Solution
By moving the `three` package to `devDependencies`:
- Users can choose their preferred Three.js version
- We prevent the installation of multiple `three` instances