### PR TITLE
Add: RequestManager interface to replace getUrl and XhrRequest

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -73,7 +73,7 @@ document.body.onload = function()
 	
 	function loadPointCloud(baseUrl: string, url: string, position?: Vector3, rotation?: Euler, scale?: Vector3)
 	{
-			potree.loadPointCloud(url, url => `${baseUrl}${url}`,).then(function(pco: PointCloudOctree)
+		potree.loadPointCloud(url, baseUrl).then(function(pco: PointCloudOctree)
 			{
 				pco.material.size = 1.0;
 				pco.material.shape = 2;

--- a/source/loading2/RequestManager.ts
+++ b/source/loading2/RequestManager.ts
@@ -1,0 +1,19 @@
+export interface RequestManager {
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+  getUrl(url: string): Promise<string>;
+}
+
+/* Example Custom RequestManager
+
+class CustomRequestManager implements RequestManager 
+{
+  fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+    throw new Error("Method not implemented.")
+  }
+
+  async getUrl(url: string): Promise<string> {
+    return url;
+  }
+}
+
+*/

--- a/source/loading2/load-octree.ts
+++ b/source/loading2/load-octree.ts
@@ -1,14 +1,12 @@
 import {OctreeLoader} from './OctreeLoader';
-import {GetUrlFn, XhrRequest} from '../loading/types';
+import {type RequestManager} from './RequestManager';
 
 export async function loadOctree(
 	url: string,
-	getUrl: GetUrlFn,
-	xhrRequest: XhrRequest,
+	requestManager: RequestManager
 ) 
 {
-	const trueUrl = await getUrl(url);
 	const loader = new OctreeLoader();
-	const {geometry} = await loader.load(trueUrl, xhrRequest);
+	const {geometry} = await loader.load(url, requestManager);
 	return geometry;
 }

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -1,3 +1,4 @@
+import { RequestManager } from './loading2/RequestManager';
 import {OctreeGeometry} from './loading2/OctreeGeometry';
 import {loadOctree} from './loading2/load-octree';
 import {
@@ -19,7 +20,7 @@ import {
 	PERSPECTIVE_CAMERA
 } from './constants';
 import {getFeatures} from './features';
-import {GetUrlFn, loadPOC} from './loading';
+import {loadPOC} from './loading';
 import {ClipMode} from './materials';
 import {PointCloudOctree} from './point-cloud-octree';
 import {PointCloudOctreeGeometryNode} from './point-cloud-octree-geometry-node';
@@ -59,21 +60,38 @@ export class Potree implements IPotree
 
 	lru = new LRU(this._pointBudget);
 
-	async loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest = (input: RequestInfo, init?: RequestInit) => {return fetch(input, init);}): Promise<PointCloudOctree> 
-	{
-		if (url === 'cloud.js') 
-		{
-			return await loadPOC(url, getUrl, xhrRequest).then((geometry) => {
-				return new PointCloudOctree(this, geometry);
-			});
-		}
-		else if (url === 'metadata.json') 
-		{
-			return await loadOctree(url, getUrl, xhrRequest).then((geometry: OctreeGeometry) => {
-				return new PointCloudOctree(this, geometry);});
-		}
-		throw new Error('Unsupported file type');
-	}
+	async loadPointCloud(url: string, baseUrl: string): Promise<PointCloudOctree>;
+  async loadPointCloud(url: string, requestManager: RequestManager): Promise<PointCloudOctree>;
+  async loadPointCloud(
+    url: string,
+    arg: string | RequestManager
+  ): Promise<PointCloudOctree> {
+    if (typeof arg === 'string') {
+      // Handle baseUrl case
+      const baseUrl = arg;
+
+      const requestManager: RequestManager = {
+        getUrl: async (relativeUrl) => `${baseUrl}${relativeUrl}`,
+        fetch: async (input, init) => fetch(input, init),
+      };
+      return this.loadPointCloud(url, requestManager);
+    } else {
+      // Handle RequestManager case
+      const requestManager = arg;
+
+      if (url === 'cloud.js') {
+        return await loadPOC(url, requestManager.getUrl, requestManager.fetch).then((geometry) => {
+          return new PointCloudOctree(this, geometry);
+        });
+      } else if (url === 'metadata.json') {
+        return await loadOctree(url, requestManager).then((geometry: OctreeGeometry) => {
+          return new PointCloudOctree(this, geometry);
+        });
+      }
+
+      throw new Error('Unsupported file type');
+    }
+  }
 
 	updatePointClouds(
 		pointClouds: PointCloudOctree[],

--- a/source/types.ts
+++ b/source/types.ts
@@ -1,9 +1,10 @@
+import {RequestManager} from './loading2/RequestManager';
 import {OctreeGeometry} from './loading2/OctreeGeometry';
 import {PointCloudOctreeGeometry} from './point-cloud-octree-geometry';
 import {Box3, Camera, Sphere, Vector3, WebGLRenderer} from 'three';
-import {GetUrlFn, XhrRequest} from './loading/types';
 import {PointCloudOctree} from './point-cloud-octree';
 import {LRU} from './utils/lru';
+
 
 export interface IPointCloudTreeNode {
   id: number;
@@ -47,7 +48,8 @@ export interface IPotree {
   maxNumNodesLoading: number;
   lru: LRU;
 
-  loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest?: XhrRequest): Promise<PointCloudOctree>;
+  loadPointCloud(url: string, baseUrl: string): Promise<PointCloudOctree>;
+  loadPointCloud(url: string, requestManager: RequestManager): Promise<PointCloudOctree>;
 
   updatePointClouds(
     pointClouds: PointCloudOctree[],


### PR DESCRIPTION
This pull request aims to replace the pattern of passing getUrl and xhrRequest with a RequestManager interface (#54).

I decided to just use an interface to wrap these up, instead of a heavier weight class, so that it's easier to make compatible with the POC loader. I can make changes to the POC loader to use the RequestManager directly instead, but I wanted to get some feedback first before committing to that. 

With this setup it is incorrect to call requestManager.fetch(url) without transforming the url with requestManager.getUrl(url) first. This allows for unwanted behavior, so it might be better to find a more complex way of representing a RequestManager.