### PR TITLE
Allow specifying a custom material when loading the pointcloud.

### DIFF
--- a/source/point-cloud-octree.ts
+++ b/source/point-cloud-octree.ts
@@ -66,7 +66,7 @@ export class PointCloudOctree extends PointCloudTree
 		this.position.copy(pcoGeometry.offset);
 		this.updateMatrix();
 
-		this.material = material || pcoGeometry instanceof OctreeGeometry ? new PointCloudMaterial({newFormat: true}) : new PointCloudMaterial();
+		this.material = material || (pcoGeometry instanceof OctreeGeometry ? new PointCloudMaterial({newFormat: true}) : new PointCloudMaterial());
 		this.initMaterial(this.material);
 	}
 

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -20,7 +20,7 @@ import {
 } from './constants';
 import {getFeatures} from './features';
 import {GetUrlFn, loadPOC} from './loading';
-import {ClipMode} from './materials';
+import {ClipMode, PointCloudMaterial} from './materials';
 import {PointCloudOctree} from './point-cloud-octree';
 import {PointCloudOctreeGeometryNode} from './point-cloud-octree-geometry-node';
 import {PointCloudOctreeNode} from './point-cloud-octree-node';
@@ -59,18 +59,23 @@ export class Potree implements IPotree
 
 	lru = new LRU(this._pointBudget);
 
-	async loadPointCloud(url: string, getUrl: GetUrlFn, xhrRequest = (input: RequestInfo, init?: RequestInit) => {return fetch(input, init);}): Promise<PointCloudOctree> 
+	async loadPointCloud(
+	  url: string,
+	  getUrl: GetUrlFn,
+	  xhrRequest = (input: RequestInfo, init?: RequestInit) => {return fetch(input, init);},
+	  material?: PointCloudMaterial,
+	): Promise<PointCloudOctree>
 	{
 		if (url === 'cloud.js') 
 		{
 			return await loadPOC(url, getUrl, xhrRequest).then((geometry) => {
-				return new PointCloudOctree(this, geometry);
+				return new PointCloudOctree(this, geometry, material);
 			});
 		}
 		else if (url === 'metadata.json') 
 		{
 			return await loadOctree(url, getUrl, xhrRequest).then((geometry: OctreeGeometry) => {
-				return new PointCloudOctree(this, geometry);});
+				return new PointCloudOctree(this, geometry, material);});
 		}
 		throw new Error('Unsupported file type');
 	}


### PR DESCRIPTION
This should allow using customized materials.
I saw that `PointCloudOctree` already took an optional material, so I wired this up such that it's customizable, it shouldn't be a breaking change this way.

I think setting the material in `PointCloudOctree` was wrong previously (taking precedence of the ternary operator into account).