### PR TITLE
feat(edl): add Eye-Dome Lighting (EDL) render pipeline for point clouds

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -7,5 +7,7 @@ export * from './point-cloud-octree-picker';
 export * from './point-cloud-octree';
 export * from './point-cloud-tree';
 export * from './potree';
+export * from './rendering/edl-pass';
+export * from './rendering/potree-renderer';
 export * from './types';
 export * from './version';

--- a/source/materials/eye-dome-lighting-material.ts
+++ b/source/materials/eye-dome-lighting-material.ts
@@ -1,0 +1,92 @@
+import { GLSL3, Matrix4, RawShaderMaterial, Texture } from 'three';
+import { IUniform } from './types';
+
+const VertShader = require('./shaders/edl.vs').default;
+const FragShader = require('./shaders/edl.fs').default;
+
+export interface IEyeDomeLightingMaterialUniforms {
+	[name: string]: IUniform<any>;
+
+	screenWidth: IUniform<number>;
+	screenHeight: IUniform<number>;
+	edlStrength: IUniform<number>;
+	radius: IUniform<number>;
+	opacity: IUniform<number>;
+
+	neighbours: IUniform<Float32Array>;
+
+	uProj: IUniform<Float32Array>;
+	colorMap: IUniform<Texture | null>;
+}
+
+export class EyeDomeLightingMaterial extends RawShaderMaterial {
+	public uniforms: IEyeDomeLightingMaterialUniforms;
+
+	private _neighbourCount: number = 8;
+	private neighboursArray: Float32Array = new Float32Array(16);
+
+	public constructor() {
+		super();
+
+		this.uniforms = {
+			screenWidth: { type: 'f', value: 1 },
+			screenHeight: { type: 'f', value: 1 },
+			edlStrength: { type: 'f', value: 1.0 },
+			radius: { type: 'f', value: 1.4 },
+			opacity: { type: 'f', value: 1.0 },
+
+			neighbours: { type: '2fv', value: this.neighboursArray },
+			uProj: { type: 'Matrix4fv', value: new Float32Array(16) },
+			colorMap: { type: 't', value: null },
+		};
+
+		this.glslVersion = GLSL3;
+		this.depthTest = true;
+		this.depthWrite = true;
+		this.transparent = true;
+
+		// Initialize neighbour offsets even when the default count matches.
+		this.initializeNeighboursArray(this._neighbourCount);
+
+		this.updateShaderSource();
+	}
+
+	public get neighbourCount(): number {
+		return this._neighbourCount;
+	}
+
+	public set neighbourCount(value: number) {
+		const next = Math.max(1, Math.floor(value));
+		if (this._neighbourCount !== next) {
+			this._neighbourCount = next;
+			this.initializeNeighboursArray(this._neighbourCount);
+			this.updateShaderSource();
+		}
+	}
+
+	private initializeNeighboursArray(neighbourCount: number): void {
+		this.neighboursArray = new Float32Array(neighbourCount * 2);
+		for (let c = 0; c < neighbourCount; c++) {
+			this.neighboursArray[2 * c + 0] = Math.cos((2 * c * Math.PI) / neighbourCount);
+			this.neighboursArray[2 * c + 1] = Math.sin((2 * c * Math.PI) / neighbourCount);
+		}
+		this.uniforms.neighbours.value = this.neighboursArray;
+	}
+
+	private getDefines(): string {
+		return `#define NEIGHBOUR_COUNT ${this._neighbourCount}\n`;
+	}
+
+	public updateShaderSource(): void {
+		const defines = this.getDefines();
+		this.vertexShader = defines + VertShader;
+		this.fragmentShader = defines + FragShader;
+		this.needsUpdate = true;
+	}
+
+	public setProjectionMatrix(projectionMatrix: Matrix4): void {
+		const out = new Float32Array(16);
+		out.set(projectionMatrix.elements);
+		this.uniforms.uProj.value = out;
+	}
+}

--- a/source/materials/index.ts
+++ b/source/materials/index.ts
@@ -1,6 +1,7 @@
 export * from './blur-material';
 export * from './clipping';
 export * from './enums';
+export * from './eye-dome-lighting-material';
 export * from './point-cloud-material';
 export * from './texture-generation';
 export * from './types';

--- a/source/materials/shaders/edl.vs
+++ b/source/materials/shaders/edl.vs
@@ -1,10 +1,17 @@
-// Declare a varying vec2 to pass UV coordinates to the fragment shader
-varying vec2 vUv;
+precision highp float;
+
+in vec3 position;
+in vec2 uv;
+
+uniform mat4 projectionMatrix;
+uniform mat4 modelViewMatrix;
+
+out vec2 vUv;
 
 void main() {
 	// Assign the UV coordinates from the vertex data to vUv
 	vUv = uv;
-	
+
 	// Compute the model-view position of the vertex
 	vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
 

--- a/source/materials/shaders/pointcloud.fs
+++ b/source/materials/shaders/pointcloud.fs
@@ -41,10 +41,7 @@ out vec4 fragColor;
 	in float vLinearDepth;
 #endif
 
-#ifdef use_edl
-	// Log depth for EDL rendering
-	in float vLogDepth;
-#endif
+
 
 in vec3 vViewPosition;
 #if defined(weighted_splats) || defined(paraboloid_point_shape)
@@ -206,8 +203,10 @@ void main() {
 	#endif
 
 	#if defined(use_edl)
-		// For EDL, pass the log depth
-		fragColor.a = vLogDepth;
+		// For EDL, store log2(linearDepth) in alpha.
+		// This is recomputed here (rather than in VS) so it matches per-fragment depth
+		// adjustments such as paraboloid point shape.
+		fragColor.a = log2(max(linearDepth, 1e-6));
 	#endif
 
 	#if defined(highlight_point)

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -95,9 +95,7 @@ uniform sampler2D depthMap;
 	out float vLinearDepth;
 #endif
 
-#ifdef use_edl
-	out float vLogDepth;
-#endif
+
 
 out vec3 vViewPosition;
 
@@ -341,9 +339,8 @@ void main() {
 		vNormal = normalize(normalMatrix * normal);
 	#endif
 
-	#ifdef use_edl
-		vLogDepth = log2(-mvPosition.z);
-	#endif
+	// EDL alpha (log2(linearDepth)) is written in the fragment shader so it can
+	// account for per-fragment depth adjustments (e.g. paraboloid point shape).
 
 
 	// POINT SIZE COMPUTATION

--- a/source/rendering/edl-pass.ts
+++ b/source/rendering/edl-pass.ts
@@ -1,0 +1,192 @@
+import {
+    Camera,
+    Color,
+    FloatType,
+    HalfFloatType,
+    NearestFilter,
+    Object3D,
+    OrthographicCamera,
+    PerspectiveCamera,
+    RGBAFormat,
+    UnsignedByteType,
+    Vector2,
+    WebGLRenderer,
+    WebGLRenderTarget,
+} from 'three';
+
+import { EyeDomeLightingMaterial } from '../materials/eye-dome-lighting-material';
+import { PointCloudOctree } from '../point-cloud-octree';
+import { ScreenPass } from './screen-pass';
+
+export type EDLPassParams = {
+    renderer: WebGLRenderer;
+    scene: Object3D;
+    camera: Camera;
+    pointClouds?: PointCloudOctree[];
+    pointCloudLayer?: number;
+};
+
+function isPerspectiveOrOrthographicCamera(camera: Camera): camera is PerspectiveCamera | OrthographicCamera {
+    return (camera as PerspectiveCamera).isPerspectiveCamera === true || (camera as OrthographicCamera).isOrthographicCamera === true;
+}
+
+export class EDLPass {
+    public edlStrength: number = 0.4;
+    public radius: number = 1.4;
+    public opacity: number = 1.0;
+    public neighbourCount: number = 8;
+
+    private rtEDL: WebGLRenderTarget;
+    private rtTypeChecked = false;
+    private edlMaterial: EyeDomeLightingMaterial;
+    private screenPass: ScreenPass;
+    private size = new Vector2();
+
+    public constructor() {
+        this.edlMaterial = new EyeDomeLightingMaterial();
+        this.screenPass = new ScreenPass();
+
+        this.rtEDL = new WebGLRenderTarget(1, 1, {
+            minFilter: NearestFilter,
+            magFilter: NearestFilter,
+            format: RGBAFormat,
+            type: HalfFloatType,
+            depthBuffer: true,
+        });
+
+        // WebGL2 + float color buffers are required for robust quality.
+        this.rtEDL.texture.generateMipmaps = false;
+    }
+
+    private ensureRenderTargetType(renderer: WebGLRenderer): void {
+        if (this.rtTypeChecked) {
+            return;
+        }
+
+        this.rtTypeChecked = true;
+
+        const gl = renderer.getContext();
+        const isWebGL2 = renderer.capabilities.isWebGL2 === true;
+
+        // We encode depth in alpha, so we want as much precision as possible.
+        // Prefer FloatType when WebGL2 + EXT_color_buffer_float is available.
+        // Otherwise fall back to HalfFloatType (WebGL1: EXT_color_buffer_half_float),
+        // and finally UnsignedByteType as a last resort.
+        const hasColorBufferFloat = Boolean(
+            gl.getExtension('EXT_color_buffer_float') ||
+            gl.getExtension('WEBGL_color_buffer_float'),
+        );
+        const hasColorBufferHalfFloat = Boolean(gl.getExtension('EXT_color_buffer_half_float'));
+
+        let desiredType: any = UnsignedByteType;
+        if (isWebGL2 && hasColorBufferFloat) {
+            desiredType = FloatType;
+        } else if (!isWebGL2 && (hasColorBufferHalfFloat || hasColorBufferFloat)) {
+            desiredType = HalfFloatType;
+        }
+
+        if (this.rtEDL.texture.type !== desiredType) {
+            const w = this.rtEDL.width;
+            const h = this.rtEDL.height;
+            this.rtEDL.dispose();
+            this.rtEDL = new WebGLRenderTarget(w, h, {
+                minFilter: NearestFilter,
+                magFilter: NearestFilter,
+                format: RGBAFormat,
+                type: desiredType,
+                depthBuffer: true,
+            });
+            this.rtEDL.texture.generateMipmaps = false;
+        }
+    }
+
+    public dispose(): void {
+        this.rtEDL.dispose();
+
+        // Three.js does not automatically release GPU resources on GC.
+        // Explicitly dispose materials/geometry we own.
+        this.edlMaterial.dispose();
+        this.screenPass.dispose();
+    }
+
+    private resizeToRenderer(renderer: WebGLRenderer): void {
+        renderer.getSize(this.size);
+        const dpr = renderer.getPixelRatio();
+        const width = Math.max(1, Math.floor(this.size.x * dpr));
+        const height = Math.max(1, Math.floor(this.size.y * dpr));
+
+        if (this.rtEDL.width !== width || this.rtEDL.height !== height) {
+            this.rtEDL.setSize(width, height);
+        }
+    }
+
+    public render(params: EDLPassParams): void {
+        const { renderer, scene, camera } = params;
+        const pointCloudLayer = params.pointCloudLayer ?? 1;
+
+        this.ensureRenderTargetType(renderer);
+
+        this.resizeToRenderer(renderer);
+
+        // Ensure shader define counts are correct.
+        if (this.edlMaterial.neighbourCount !== this.neighbourCount) {
+            this.edlMaterial.neighbourCount = this.neighbourCount;
+        }
+
+        const oldAutoClear = renderer.autoClear;
+        renderer.autoClear = false;
+
+        const oldTarget = renderer.getRenderTarget();
+        const oldLayerMask = camera.layers.mask;
+
+        // Clear default framebuffer
+        renderer.setRenderTarget(null);
+        renderer.clear(true, true, true);
+
+        // 1) Render everything the camera would normally render, except the point-cloud layer.
+        // This respects user-defined layer masks.
+        camera.layers.mask = oldLayerMask & ~(1 << pointCloudLayer);
+        renderer.render(scene, camera);
+
+        // 2) Render pointclouds into offscreen target.
+        // Note: We intentionally do NOT mutate point-cloud materials here.
+        // Material flags (e.g. `useEDL`) should be configured by the caller when enabling/disabling EDL.
+
+        // Background marker: we clear alpha==1.0 so the EDL shader can discard background fragments.
+        // Note: This matches upstream Potree behavior. In theory, the EDL alpha channel stores log2(linearDepth),
+        // so alpha==1.0 can collide with real geometry when linearDepth==2.0 exactly.
+        // We keep the upstream convention for visual parity; collisions are expected to be extremely rare in practice.
+        const oldClearColor = new Color();
+        renderer.getClearColor(oldClearColor);
+        const oldClearAlpha = renderer.getClearAlpha();
+        renderer.setClearColor(0x000000, 1);
+
+        renderer.setRenderTarget(this.rtEDL);
+        renderer.clear(true, true, true);
+
+        renderer.setClearColor(oldClearColor, oldClearAlpha);
+        camera.layers.mask = 1 << pointCloudLayer;
+        renderer.render(scene, camera);
+
+        // 3) EDL fullscreen pass (depth-tested against layer0 depth buffer)
+        this.edlMaterial.uniforms.screenWidth.value = this.rtEDL.width;
+        this.edlMaterial.uniforms.screenHeight.value = this.rtEDL.height;
+        this.edlMaterial.uniforms.edlStrength.value = this.edlStrength;
+        this.edlMaterial.uniforms.radius.value = this.radius;
+        this.edlMaterial.uniforms.opacity.value = this.opacity;
+        this.edlMaterial.uniforms.colorMap.value = this.rtEDL.texture;
+        if (!isPerspectiveOrOrthographicCamera(camera)) {
+            throw new Error('EDLPass.render: camera must be PerspectiveCamera or OrthographicCamera');
+        }
+        this.edlMaterial.setProjectionMatrix(camera.projectionMatrix);
+
+        renderer.setRenderTarget(null);
+        // Keep existing depth buffer from layer0 render.
+        this.screenPass.render(renderer, this.edlMaterial, null);
+
+        // restore state
+        camera.layers.mask = oldLayerMask;
+        renderer.setRenderTarget(oldTarget);
+        renderer.autoClear = oldAutoClear;
+    }
+}

--- a/source/rendering/potree-renderer.ts
+++ b/source/rendering/potree-renderer.ts
@@ -1,0 +1,221 @@
+import { Camera, Object3D, WebGLRenderer } from 'three';
+
+import { PointCloudMaterial } from '../materials/point-cloud-material';
+import { PointCloudOctree } from '../point-cloud-octree';
+import { Potree } from '../potree';
+import { IVisibilityUpdateResult } from '../types';
+import { EDLPass } from './edl-pass';
+
+/**
+ * Configuration for Eye-Dome Lighting (EDL) rendering.
+ *
+ * Note: EDL is a multi-pass / post-process effect (render default layer 0 (non-pointcloud), render point clouds to an offscreen target,
+ * then composite). Therefore it cannot be expressed as a single `renderer.render(scene, camera)` call.
+ */
+export type PotreeRendererEDLOptions = {
+    enabled: boolean;
+    /** Defaults to 1 so layer 0 can remain reserved for non-pointcloud content in the first pass. */
+    pointCloudLayer?: number;
+    strength?: number;
+    radius?: number;
+    opacity?: number;
+    neighbourCount?: number;
+};
+
+/**
+ * Options for {@link PotreeRenderer}.
+ *
+ * This is intentionally additive and does not change existing Potree APIs.
+ */
+export type PotreeRendererOptions = {
+    edl?: PotreeRendererEDLOptions;
+};
+
+/**
+ * Parameters required to render a frame.
+ */
+export type PotreeRendererRenderParams = {
+    renderer: WebGLRenderer;
+    scene: Object3D;
+    camera: Camera;
+    pointClouds?: PointCloudOctree[];
+};
+
+/**
+ * Thin helper that renders Potree point clouds.
+ *
+ * Why this exists:
+ * - Without EDL, users typically do: `potree.updatePointClouds(...)` then `renderer.render(scene, camera)`.
+ * - With EDL enabled, users previously had to manually:
+ *   1) keep point-cloud objects on a dedicated layer, and
+ *   2) run `EDLPass.render(...)` instead of `renderer.render(...)`.
+ *
+ * `PotreeRenderer` keeps that wiring in one place while preserving backward compatibility.
+ */
+export class PotreeRenderer {
+    private edlPass: EDLPass | null = null;
+    private edlOptions: PotreeRendererEDLOptions = { enabled: false, pointCloudLayer: 1 };
+    private lastPointClouds: PointCloudOctree[] | null = null;
+    private overriddenMaterials = new WeakMap<PointCloudMaterial, { useEDL: boolean; weighted: boolean }>();
+    private overriddenLayerMasks = new WeakMap<PointCloudOctree, number>();
+
+    public constructor(options: PotreeRendererOptions = {}) {
+        if (options.edl) {
+            this.setEDL(options.edl);
+        }
+    }
+
+    /** Releases internally owned GPU resources (render targets). */
+    public dispose(): void {
+        this.edlPass?.dispose();
+        this.edlPass = null;
+    }
+
+    /**
+     * Enables/disables EDL and updates EDL parameters.
+     *
+     * This method is safe to call at runtime (e.g. toggling EDL on/off).
+     */
+    public setEDL(options: PotreeRendererEDLOptions): void {
+        const prevEnabled = Boolean(this.edlOptions.enabled);
+        this.edlOptions = {
+            enabled: options.enabled,
+            pointCloudLayer: options.pointCloudLayer ?? this.edlOptions.pointCloudLayer ?? 1,
+            strength: options.strength ?? this.edlOptions.strength,
+            radius: options.radius ?? this.edlOptions.radius,
+            opacity: options.opacity ?? this.edlOptions.opacity,
+            neighbourCount: options.neighbourCount ?? this.edlOptions.neighbourCount,
+        };
+
+        if (this.edlOptions.enabled && !this.edlPass) {
+            this.edlPass = new EDLPass();
+        }
+
+        if (this.edlPass) {
+            if (this.edlOptions.strength !== undefined) this.edlPass.edlStrength = this.edlOptions.strength;
+            if (this.edlOptions.radius !== undefined) this.edlPass.radius = this.edlOptions.radius;
+            if (this.edlOptions.opacity !== undefined) this.edlPass.opacity = this.edlOptions.opacity;
+            if (this.edlOptions.neighbourCount !== undefined) this.edlPass.neighbourCount = this.edlOptions.neighbourCount;
+        }
+
+        // Apply/restore EDL-related state only when toggling enabled state.
+        const nextEnabled = Boolean(this.edlOptions.enabled);
+        if (prevEnabled !== nextEnabled) {
+            if (this.lastPointClouds) {
+                this.applyEDLState(this.lastPointClouds, nextEnabled);
+            }
+        }
+    }
+
+    private setLayerMaskRecursive(root: Object3D, desiredMask: number): void {
+        if (root.layers.mask !== desiredMask) {
+            root.layers.mask = desiredMask;
+        }
+
+        root.traverse((obj: Object3D) => {
+            if (obj.layers.mask !== desiredMask) {
+                obj.layers.mask = desiredMask;
+            }
+        });
+    }
+
+    /**
+     * Ensures all point-cloud objects (including newly created child nodes) are on the provided layer.
+      * Side effect: overwrites `Object3D.layers` for the point cloud subtree.
+     *
+     * When EDL is enabled, layer separation is required so we can render:
+     * - non-pointcloud content first (layer 0), then
+     * - point clouds on a dedicated layer into an offscreen target.
+     */
+    public syncPointCloudLayers(pointClouds: PointCloudOctree[], layer: number): void {
+        const desiredMask = 1 << layer;
+        for (const pco of pointClouds) {
+            this.setLayerMaskRecursive(pco, desiredMask);
+        }
+    }
+
+    private applyEDLState(pointClouds: PointCloudOctree[], enabled: boolean): void {
+        const pointCloudLayer = this.edlOptions.pointCloudLayer ?? 1;
+        const desiredMask = 1 << pointCloudLayer;
+
+        for (const pco of pointClouds) {
+            const material = pco.material;
+
+            if (enabled) {
+                // Remember + override material flags (one-time per material).
+                if (!this.overriddenMaterials.has(material)) {
+                    this.overriddenMaterials.set(material, { useEDL: material.useEDL, weighted: material.weighted });
+                }
+                // Only write when needed to avoid accidental per-frame shader churn.
+                if (material.useEDL !== true) material.useEDL = true;
+                if (material.weighted !== false) material.weighted = false;
+
+                // Remember + override layers (one-time per point cloud).
+                if (!this.overriddenLayerMasks.has(pco)) {
+                    this.overriddenLayerMasks.set(pco, pco.layers.mask);
+                }
+                // Keep point-cloud subtree on the dedicated layer.
+                // Point cloud nodes are created dynamically during streaming; even if the root mask matches,
+                // newly created child nodes may still be on a different layer unless we resync.
+                this.setLayerMaskRecursive(pco, desiredMask);
+            } else {
+                // Restore material flags if we previously overrode them.
+                const prevMat = this.overriddenMaterials.get(material);
+                if (prevMat) {
+                    if (material.useEDL !== prevMat.useEDL) material.useEDL = prevMat.useEDL;
+                    if (material.weighted !== prevMat.weighted) material.weighted = prevMat.weighted;
+                }
+
+                // Restore layer mask if we previously overrode it.
+                const prevMask = this.overriddenLayerMasks.get(pco);
+                if (prevMask !== undefined) {
+                    this.setLayerMaskRecursive(pco, prevMask);
+                }
+            }
+        }
+    }
+
+    /**
+     * Renders a frame.
+     *
+     * - EDL disabled: calls `renderer.render(scene, camera)`.
+     * - EDL enabled: runs the EDL multi-pass pipeline via {@link EDLPass}.
+     */
+    public render(params: PotreeRendererRenderParams): void {
+        const { renderer, scene, camera, pointClouds } = params;
+
+        const edlEnabled = Boolean(this.edlOptions.enabled);
+        const pointCloudLayer = this.edlOptions.pointCloudLayer ?? 1;
+
+        if (pointClouds) {
+            this.lastPointClouds = pointClouds;
+            // Apply/restore state for these point clouds.
+            this.applyEDLState(pointClouds, edlEnabled);
+        }
+
+        if (edlEnabled) {
+            if (!this.edlPass) {
+                this.edlPass = new EDLPass();
+                this.setEDL(this.edlOptions);
+            }
+
+            this.edlPass.render({ renderer, scene, camera, pointClouds, pointCloudLayer });
+            return;
+        }
+
+        renderer.render(scene, camera);
+    }
+
+    /** Convenience helper: `updatePointClouds()` followed by {@link render}. */
+    public updateAndRender(
+        potree: Potree,
+        pointClouds: PointCloudOctree[],
+        camera: Camera,
+        renderer: WebGLRenderer,
+        scene: Object3D,
+    ): IVisibilityUpdateResult {
+        const result = potree.updatePointClouds(pointClouds, camera, renderer);
+        this.render({ renderer, scene, camera, pointClouds });
+        return result;
+    }
+}

--- a/source/rendering/screen-pass.ts
+++ b/source/rendering/screen-pass.ts
@@ -1,0 +1,68 @@
+import {
+	BufferAttribute,
+	BufferGeometry,
+	Mesh,
+	OrthographicCamera,
+	RawShaderMaterial,
+	Scene,
+	WebGLRenderer,
+	WebGLRenderTarget,
+} from 'three';
+
+export class ScreenPass {
+	private scene: Scene;
+	private camera: OrthographicCamera;
+	private quad: Mesh;
+	private geometry: BufferGeometry;
+	private placeholderMaterial: RawShaderMaterial;
+
+	public constructor() {
+		this.scene = new Scene();
+		this.camera = new OrthographicCamera(-1, 1, 1, -1, 0, 1);
+
+		this.geometry = new BufferGeometry();
+		// Fullscreen triangle would be slightly faster, but a quad is fine and simple.
+		const positions = new Float32Array([
+			-1, -1, 0,
+			1, -1, 0,
+			1, 1, 0,
+			-1, 1, 0,
+		]);
+		const uvs = new Float32Array([
+			0, 0,
+			1, 0,
+			1, 1,
+			0, 1,
+		]);
+		const indices = new Uint16Array([0, 1, 2, 0, 2, 3]);
+		this.geometry.setIndex(new BufferAttribute(indices, 1));
+		this.geometry.setAttribute('position', new BufferAttribute(positions, 3));
+		this.geometry.setAttribute('uv', new BufferAttribute(uvs, 2));
+
+		// Placeholder material: we do not own/assume ownership of materials passed to render().
+		this.placeholderMaterial = new RawShaderMaterial();
+		this.quad = new Mesh(this.geometry, this.placeholderMaterial);
+		this.scene.add(this.quad);
+	}
+
+	public dispose(): void {
+		// Only dispose resources owned by this pass.
+		this.geometry.dispose();
+		this.placeholderMaterial.dispose();
+	}
+
+	public render(
+		renderer: WebGLRenderer,
+		material: RawShaderMaterial,
+		target: WebGLRenderTarget | null = null,
+	): void {
+		const oldTarget = renderer.getRenderTarget();
+
+		this.quad.material = material;
+
+		renderer.setRenderTarget(target);
+		renderer.render(this.scene, this.camera);
+
+		renderer.setRenderTarget(oldTarget);
+	}
+}


### PR DESCRIPTION
This PR adds Eye-Dome Lighting (EDL) support to potree-core as an opt-in, multi-pass rendering pipeline for point clouds.

**What’s included**
- Add `EDLPass` (offscreen pointcloud pass + fullscreen composite pass).
- Add `EyeDomeLightingMaterial` (GLSL3) and a small `ScreenPass` helper.
- Add `PotreeRenderer` helper to toggle EDL without changing existing `Potree.updatePointClouds(...)` usage patterns.
- Fix EDL depth encoding for point clouds so alpha uses `log2(linearDepth)` computed in the fragment stage (matches per-fragment depth adjustments such as paraboloid point shape).
- Explicitly dispose GPU resources owned by the EDL pipeline (`WebGLRenderTarget`, fullscreen geometry/material).

**Behavior / Compatibility**
- Fully opt-in: existing apps can keep using `renderer.render(scene, camera)` unchanged.
- When enabled, EDL uses a dedicated layer for point clouds (default: layer 1) so non-pointcloud content can be rendered first and depth-composited correctly.

**Screenshot**
EDL OFF vs EDL ON (see attached image) — edges and fine surface details become more readable with EDL enabled.

**Notes**
- Background handling follows upstream Potree convention (EDL RT alpha cleared to 1.0 and treated as background) for visual parity.

**How to use**
```ts
const potreeRenderer = new PotreeRenderer({
  edl: { enabled: true, pointCloudLayer: 1, strength: 0.4, radius: 1.4, opacity: 1.0 },
});

// per frame:
potreeRenderer.render({ renderer, scene, camera, pointClouds });
```

<img width="828" height="463" alt="image" src="https://github.com/user-attachments/assets/8af9d042-68f7-4283-a407-683626ad32f6" />