### PR TITLE
Support reversed depth buffer

### DIFF
--- a/source/materials/eye-dome-lighting-material.ts
+++ b/source/materials/eye-dome-lighting-material.ts
@@ -18,7 +18,6 @@ export interface IEyeDomeLightingMaterialUniforms {
 	uProj: IUniform<Float32Array>;
 	colorMap: IUniform<Texture | null>;
 	far: IUniform<number>;
-	useLogDepth: IUniform<boolean>;
 	useOrthographicCamera: IUniform<boolean>;
 }
 
@@ -26,6 +25,8 @@ export class EyeDomeLightingMaterial extends RawShaderMaterial {
 	public uniforms: IEyeDomeLightingMaterialUniforms;
 
 	private _neighbourCount: number = 8;
+	private _useLogDepth = false;
+	private _useReversedDepth = false;
 	private neighboursArray: Float32Array = new Float32Array(16);
 
 	public constructor() {
@@ -42,7 +43,6 @@ export class EyeDomeLightingMaterial extends RawShaderMaterial {
 			uProj: { type: 'Matrix4fv', value: new Float32Array(16) },
 			colorMap: { type: 't', value: null },
 			far: { type: 'f', value: 1000.0 },
-			useLogDepth: { type: 'b', value: false },
 			useOrthographicCamera: { type: 'b', value: false },
 		};
 
@@ -70,6 +70,28 @@ export class EyeDomeLightingMaterial extends RawShaderMaterial {
 		}
 	}
 
+	public set useLogDepth(value: boolean) {
+		if (this._useLogDepth !== value) {
+			this._useLogDepth = value;
+			this.updateShaderSource();
+		}
+	}
+
+	public get useLogDepth(): boolean {
+		return this._useLogDepth;
+	}
+
+	public set useReversedDepth(value: boolean) {
+		if (this._useReversedDepth !== value) {
+			this._useReversedDepth = value;
+			this.updateShaderSource();
+		}
+	}
+
+	public get useReversedDepth(): boolean {
+		return this._useReversedDepth;
+	}
+
 	private initializeNeighboursArray(neighbourCount: number): void {
 		this.neighboursArray = new Float32Array(neighbourCount * 2);
 		for (let c = 0; c < neighbourCount; c++) {
@@ -80,7 +102,14 @@ export class EyeDomeLightingMaterial extends RawShaderMaterial {
 	}
 
 	private getDefines(): string {
-		return `#define NEIGHBOUR_COUNT ${this._neighbourCount}\n`;
+		const parts = [`#define NEIGHBOUR_COUNT ${this._neighbourCount}`];
+		if (this._useLogDepth) {
+			parts.push('#define use_log_depth');
+		}
+		if (this._useReversedDepth) {
+			parts.push('#define use_reversed_depth');
+		}
+		return `${parts.join('\n')}\n`;
 	}
 
 	public updateShaderSource(): void {

--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -456,6 +456,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
 	@requiresShaderUpdate() private useLogDepth: boolean = false;
 
+	@requiresShaderUpdate() private useReversedDepth: boolean = false;
+
 	attributes = {
 		position: { type: 'fv', value: [] },
 		color: { type: 'fv', value: [] },
@@ -597,6 +599,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
 		if (this.useLogDepth) {
 			define('use_log_depth');
+		}
+
+		if (this.useReversedDepth) {
+			define('use_reversed_depth');
 		}
 
 		if (this.weighted) {
@@ -821,7 +827,14 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		// Sync clipping planes to shader uniforms
 		this.syncClippingPlanes();
 
-		this.useLogDepth = renderer.capabilities.logarithmicDepthBuffer;
+		const capabilities = renderer.capabilities as typeof renderer.capabilities & {
+			reversedDepthBuffer?: boolean;
+			reverseDepthBuffer?: boolean;
+		};
+		const useReversedDepth = capabilities.reversedDepthBuffer === true || capabilities.reverseDepthBuffer === true;
+
+		this.useReversedDepth = useReversedDepth;
+		this.useLogDepth = renderer.capabilities.logarithmicDepthBuffer && !useReversedDepth;
 
 		if (camera.type === PERSPECTIVE_CAMERA) {
 			this.useOrthographicCamera = false;

--- a/source/materials/shaders/edl.fs
+++ b/source/materials/shaders/edl.fs
@@ -19,9 +19,6 @@ uniform mat4 uProj;
 // Far plane distance, used to reconstruct logarithmic depth buffer values.
 uniform float far;
 
-// Wether the renderer is using a logarithmic depth buffer.
-uniform bool useLogDepth;
-
 // Orthographic camera flag.
 uniform bool useOrthographicCamera;
 
@@ -88,19 +85,26 @@ void main() {
 
 	// Reconstruct linear depth from the stored log2(lenearDepth) value.
 	float dl = pow(2.0, depth);
-	
-	if(useLogDepth && !useOrthographicCamera) {
-		// Logarithmic depth buffer: write depth in the same format as three.js
-		// logarithmicDepthBuffer, which uses:
-		// vFlagDepth = clipPos.w + 1.0.
-		// logDepthBufFC = 2.0 / log(far + 1.0).
-		// gl_FragDepth = log2(vFlagDepth) * logDepthBufFC * 0.5;
-		// Simplifies to: log2(linearDepth + 1.0) / log2(far + 1.0)
-		gl_FragDepth = log2(dl + 1.0) / log2(far + 1.0);
-	} else {
-		// Standard hyperbolic depth buffer.
-		vec4 dp = uProj * vec4(0.0, 0.0, -dl, 1.0);
-		float pz = dp.z / dp.w;
-		gl_FragDepth = (pz + 1.0) / 2.0;
-	}
+	vec4 dp = uProj * vec4(0.0, 0.0, -dl, 1.0);
+	float pz = dp.z / dp.w;
+
+	#if defined(use_reversed_depth)
+		float fragmentDepth = pz;
+	#else
+		float fragmentDepth = (pz + 1.0) / 2.0;
+	#endif
+
+	#if defined(use_log_depth)
+		if (!useOrthographicCamera) {
+			// Logarithmic depth buffer: write depth in the same format as three.js
+			// logarithmicDepthBuffer, which uses:
+			// vFlagDepth = clipPos.w + 1.0.
+			// logDepthBufFC = 2.0 / log(far + 1.0).
+			// gl_FragDepth = log2(vFlagDepth) * logDepthBufFC * 0.5;
+			// Simplifies to: log2(linearDepth + 1.0) / log2(far + 1.0)
+			fragmentDepth = log2(dl + 1.0) / log2(far + 1.0);
+		}
+	#endif
+
+	gl_FragDepth = fragmentDepth;
 }

--- a/source/materials/shaders/edl.fs
+++ b/source/materials/shaders/edl.fs
@@ -88,22 +88,19 @@ void main() {
 	vec4 dp = uProj * vec4(0.0, 0.0, -dl, 1.0);
 	float pz = dp.z / dp.w;
 
-	#if defined(use_reversed_depth)
+	#if defined(use_log_depth)
+		// Logarithmic depth buffer: write depth in the same format as three.js.
+		// Orthographic cameras do not use logarithmic depth, so they fall back
+		// to the standard non-logarithmic depth mapping.
+		float fragmentDepth = useOrthographicCamera
+			? ((pz + 1.0) / 2.0)
+			: (log2(dl + 1.0) / log2(far + 1.0));
+	#elif defined(use_reversed_depth)
+		// Reversed depth uses the projection-mapped depth directly.
 		float fragmentDepth = pz;
 	#else
+		// Standard hyperbolic depth buffer mapping from NDC [-1, 1] to [0, 1].
 		float fragmentDepth = (pz + 1.0) / 2.0;
-	#endif
-
-	#if defined(use_log_depth)
-		if (!useOrthographicCamera) {
-			// Logarithmic depth buffer: write depth in the same format as three.js
-			// logarithmicDepthBuffer, which uses:
-			// vFlagDepth = clipPos.w + 1.0.
-			// logDepthBufFC = 2.0 / log(far + 1.0).
-			// gl_FragDepth = log2(vFlagDepth) * logDepthBufFC * 0.5;
-			// Simplifies to: log2(linearDepth + 1.0) / log2(far + 1.0)
-			fragmentDepth = log2(dl + 1.0) / log2(far + 1.0);
-		}
 	#endif
 
 	gl_FragDepth = fragmentDepth;

--- a/source/materials/shaders/pointcloud.fs
+++ b/source/materials/shaders/pointcloud.fs
@@ -175,22 +175,26 @@ void main() {
 
 	float linearDepth = -pos.z;
 	vec4 clipPos = projectionMatrix * pos;
-	clipPos /= clipPos.w;
+	float fragmentDepth = gl_FragCoord.z;
 
 	// When using an orthographic camera, paraboloid correction is not applied,
 	// so use the GPU-compluted default depth (gl_FragCoord.z).
 	if(useOrthographicCamera){
 		// Orthographic camera: use the GPU-computed default depth.
 		// When using an orthographic camera, Three.js does not use `logarithmicDepthBuffer` either.
-		gl_FragDepth = gl_FragCoord.z;
+		gl_FragDepth = fragmentDepth;
 	}else{
 		#if defined(use_log_depth)
 			// Logarithmic depth
-			gl_FragDepth = log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0);
+			fragmentDepth = log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0);
+		#elif defined(use_reversed_depth)
+			// Recompute depth from the adjusted fragment position so paraboloid sprites
+			// depth-test using their curved surface instead of the point center.
+			fragmentDepth = clipPos.z / clipPos.w;
 		#else
-			// Use the GPU-computed default depth.
-			gl_FragDepth = gl_FragCoord.z;
+			fragmentDepth = 0.5 * (clipPos.z / clipPos.w) + 0.5;
 		#endif
+		gl_FragDepth = fragmentDepth;
 	}
 
 	#if defined(color_type_depth)

--- a/source/materials/shaders/pointcloud.fs
+++ b/source/materials/shaders/pointcloud.fs
@@ -167,35 +167,30 @@ void main() {
 	// Compute depth from view position
 	vec4 pos = vec4(vViewPosition, 1.0);
 	#if defined(paraboloid_point_shape)
-		if(!useOrthographicCamera){
-			// Adjust depth based on point shape
-			pos.z += -dot(pc, pc) * vRadius;
-		}
+		// Adjust depth based on point shape for both perspective and orthographic cameras.
+		pos.z += -dot(pc, pc) * vRadius;
 	#endif
 
 	float linearDepth = -pos.z;
 	vec4 clipPos = projectionMatrix * pos;
-	float fragmentDepth = gl_FragCoord.z;
+	float fragmentDepth;
 
-	// When using an orthographic camera, paraboloid correction is not applied,
-	// so use the GPU-compluted default depth (gl_FragCoord.z).
-	if(useOrthographicCamera){
-		// Orthographic camera: use the GPU-computed default depth.
-		// When using an orthographic camera, Three.js does not use `logarithmicDepthBuffer` either.
-		gl_FragDepth = fragmentDepth;
-	}else{
-		#if defined(use_log_depth)
-			// Logarithmic depth
-			fragmentDepth = log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0);
-		#elif defined(use_reversed_depth)
-			// Recompute depth from the adjusted fragment position so paraboloid sprites
-			// depth-test using their curved surface instead of the point center.
-			fragmentDepth = clipPos.z / clipPos.w;
-		#else
-			fragmentDepth = 0.5 * (clipPos.z / clipPos.w) + 0.5;
-		#endif
-		gl_FragDepth = fragmentDepth;
-	}
+	#if defined(use_log_depth)
+		// Three.js does not use logarithmic depth for orthographic cameras,
+		// so orthographic rendering falls back to the standard depth mapping.
+		fragmentDepth = useOrthographicCamera
+			? (0.5 * (clipPos.z / clipPos.w) + 0.5)
+			: (log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0));
+	#elif defined(use_reversed_depth)
+		// Recompute depth from the adjusted fragment position so paraboloid sprites
+		// depth-test using their curved surface instead of the point center.
+		fragmentDepth = clipPos.z / clipPos.w;
+	#else
+		// Standard hyperbolic depth buffer mapping from NDC [-1, 1] to [0, 1].
+		fragmentDepth = 0.5 * (clipPos.z / clipPos.w) + 0.5;
+	#endif
+
+	gl_FragDepth = fragmentDepth;
 
 	#if defined(color_type_depth)
 		// Render depth information into color channels

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -367,7 +367,11 @@ void main() {
 
 	pointSize = clamp(pointSize, minSize, maxSize);
 	#if defined(weighted_splats) || defined(paraboloid_point_shape)
-		vRadius = pointSize / projFactor;
+		if (useOrthographicCamera) {
+			vRadius = pointSize * orthoWidth / screenWidth;
+		} else {
+			vRadius = pointSize / projFactor;
+		}
 	#endif
 	
 	pointSize *= viewScale;

--- a/source/rendering/edl-pass.ts
+++ b/source/rendering/edl-pass.ts
@@ -182,9 +182,16 @@ export class EDLPass {
         this.edlMaterial.setProjectionMatrix(camera.projectionMatrix);
 
         // Pass far plane and log depth flag so EDL shader can reconstruct depth in the correct format.
+        const capabilities = renderer.capabilities as typeof renderer.capabilities & {
+            reversedDepthBuffer?: boolean;
+            reverseDepthBuffer?: boolean;
+        };
+        const useReversedDepth =
+            capabilities.reversedDepthBuffer === true || capabilities.reverseDepthBuffer === true;
         this.edlMaterial.uniforms.far.value = camera.far;
-        this.edlMaterial.uniforms.useLogDepth.value = renderer.capabilities.logarithmicDepthBuffer;
-        this.edlMaterial.uniforms.useOrthographicCamera.value = camera.type === ORTHOGRAPHIC_CAMERA
+        this.edlMaterial.useLogDepth = renderer.capabilities.logarithmicDepthBuffer && !useReversedDepth;
+        this.edlMaterial.useReversedDepth = useReversedDepth;
+        this.edlMaterial.uniforms.useOrthographicCamera.value = camera.type === ORTHOGRAPHIC_CAMERA;
 
         // Keep existing depth buffer from layer0 render.
         this.screenPass.render(renderer, this.edlMaterial, null);


### PR DESCRIPTION
This implements support for reversed depth buffers.

Additionally it seems that currently the normal depth buffer was broken with paraboloid point types, which is also fixed in here.
I've also changed that all the depth buffer modes are done via defines as this is usually what three.js does (and avoids branches in shaders...).
I've verified the example scene with an updated version of three.js with all configurations (ortho/perspective x log/reversed/normal).

I didn't include the update of three in here, because for one I did wanted to make this backwards compatible (somewhat...) and it resulted in a few changes not related (i.e. keep this more targeted).