### PR TITLE
Fix shader define ordering bug in syncClippingPlanes

### DIFF
--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -717,12 +717,13 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		//Only update shader source if we transition between having clipping planes and not having clipping planes.
 		//The shader only needs to know whether clipping planes are in use.
 		const doUpdate = (this.numClipPlanes === 0) !== (count === 0);
-		if (doUpdate) {
-			this.updateShaderSource();
-		}
 
 		this.numClipPlanes = count;
 		this.setUniform('clipPlaneCount', count);
+
+		if (doUpdate) {
+			this.updateShaderSource();
+		}
 
 		// If there are clipping planes, update shader uniforms each frame with their positions.
 		if (count > 0 && planes) {


### PR DESCRIPTION
**Description:**

- `syncClippingPlanes()` updated `this.numClipPlanes` after calling `updateShaderSource()`, causing `applyDefines()` to read the stale value when deciding whether to emit `#define use_clip_plane`.

- The analogous methods `setClipBoxes()` and `setClipSpheres()` correctly update their counts before calling `updateShaderSource()`. 
  -  https://github.com/tentone/potree-core/blob/master/source/materials/point-cloud-material.ts#L689-L694

- This change applies the same ordering to `syncClippingPlanes()`.


**Changes:**
- Moved `this.numClipPlanes` assignment and `setUniform('clipPlaneCount', ...)` before the conditional `updateShaderSource()`.