### PR TITLE
Revert: Avoiding unnecessary gl_FragDepth writes

### DIFF
--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -717,12 +717,13 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		//Only update shader source if we transition between having clipping planes and not having clipping planes.
 		//The shader only needs to know whether clipping planes are in use.
 		const doUpdate = (this.numClipPlanes === 0) !== (count === 0);
-		if (doUpdate) {
-			this.updateShaderSource();
-		}
 
 		this.numClipPlanes = count;
 		this.setUniform('clipPlaneCount', count);
+
+		if (doUpdate) {
+			this.updateShaderSource();
+		}
 
 		// If there are clipping planes, update shader uniforms each frame with their positions.
 		if (count > 0 && planes) {

--- a/source/materials/shaders/pointcloud.fs
+++ b/source/materials/shaders/pointcloud.fs
@@ -173,24 +173,27 @@ void main() {
 
 	float linearDepth = -pos.z;
 	vec4 clipPos = projectionMatrix * pos;
-	float fragmentDepth;
 
-	#if defined(use_log_depth)
-		// Three.js does not use logarithmic depth for orthographic cameras,
-		// so orthographic rendering falls back to the standard depth mapping.
-		fragmentDepth = useOrthographicCamera
-			? (0.5 * (clipPos.z / clipPos.w) + 0.5)
-			: (log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0));
-	#elif defined(use_reversed_depth)
-		// Recompute depth from the adjusted fragment position so paraboloid sprites
-		// depth-test using their curved surface instead of the point center.
-		fragmentDepth = clipPos.z / clipPos.w;
-	#else
-		// Standard hyperbolic depth buffer mapping from NDC [-1, 1] to [0, 1].
-		fragmentDepth = 0.5 * (clipPos.z / clipPos.w) + 0.5;
+	#if defined(paraboloid_point_shape) || defined(use_log_depth) || defined(use_reversed_depth)
+		float fragmentDepth;
+
+		#if defined(use_log_depth)
+			// Three.js does not use logarithmic depth for orthographic cameras,
+			// so orthographic rendering falls back to the standard depth mapping.
+			fragmentDepth = useOrthographicCamera
+				? (0.5 * (clipPos.z / clipPos.w) + 0.5)
+				: (log2(linearDepth + 1.0) * log(2.0) / log(far + 1.0));
+		#elif defined(use_reversed_depth)
+			// Recompute depth from the adjusted fragment position so paraboloid sprites
+			// depth-test using their curved surface instead of the point center.
+			fragmentDepth = clipPos.z / clipPos.w;
+		#else
+			// Standard hyperbolic depth buffer mapping from NDC [-1, 1] to [0, 1].
+			fragmentDepth = 0.5 * (clipPos.z / clipPos.w) + 0.5;
+		#endif
+
+		gl_FragDepth = fragmentDepth;
 	#endif
-
-	gl_FragDepth = fragmentDepth;
 
 	#if defined(color_type_depth)
 		// Render depth information into color channels


### PR DESCRIPTION
This restores the pre-2.0.15 behavior: `gl_FragDepth` is only written when paraboloid sprites, log depth, or reversed depth are enabled, so normal rendering no longer overwrites depth unnecessarily.

Related: https://github.com/tentone/potree-core/pull/77