### PR TITLE
Feature/per volume clip include exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,71 +63,58 @@ loop();
 
 ## Clip Boxes
  - Clip boxes restrict the rendered region of a point cloud to a box-shaped volume.
- - Use the `createClipBox(size, position)` helper to build an `IClipBox` from a size and world-space position.
- - Set clip boxes on the material with `setClipBoxes()`.
- - Optional per-volume mode: `mode?: "include" | "exclude"`.
-   - `include` keeps points inside the volume.
-   - `exclude` removes points inside the volume.
- - Legacy behavior remains unchanged when no clip volume has `mode` set.
+ - Use `createClipBox(size, position, mode?)` to build an `IClipBox`.
+ - `mode?: "include" | "exclude"`.
+ - `include`: clip-outside semantics for that volume (inside can stay visible).
+ - `exclude`: clip-inside semantics for that volume (inside is removed).
+ - If `mode` is `undefined`, that volume inherits the global material `clipMode`.
+ - `ClipMode.DISABLED` is a global master off switch and disables all clipping/highlighting.
+ - Clipping uses one unified rule across boxes, spheres, and clip planes:
+   - include volumes are unioned
+   - exclude volumes are unioned
+   - `B = (!hasIncludeVolumes || insideAnyInclude) && !insideAnyExclude`
+   - `P = insideAllPlanes`
+   - `S = hasBoxOrSphere`
+   - For `CLIP_OUTSIDE`: `visible = B && P`
+   - For `CLIP_INSIDE`: `visible = (S && B) || !P`
+ - Global `ClipMode.HIGHLIGHT_INSIDE` is still supported through inheritance (`mode` undefined) and only highlights without changing visibility.
+ - Clip planes are evaluated as `insideAllPlanes` (point is on the positive side of all planes).
+ - Planes are integrated into the same formulas via `P`, so plane-only behavior falls out naturally from the same equations.
 
 ```javascript
 import { ClipMode, createClipBox } from 'potree-core';
 import { Vector3 } from 'three';
 
-// Create a 5×5×5 clip box centered at world position (2, 0, 0)
-const clipBox = createClipBox(new Vector3(5, 5, 5), new Vector3(2, 0, 0));
+pco.material.clipMode = ClipMode.CLIP_OUTSIDE; // global fallback for undefined volume modes
 
-// Highlight points inside the box (other modes: CLIP_OUTSIDE, CLIP_INSIDE, DISABLED)
-pco.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
-pco.material.setClipBoxes([clipBox]);
+const includeA = createClipBox(new Vector3(10, 10, 10), new Vector3(0, 0, 0), 'include');
+const excludeB = createClipBox(new Vector3(4, 4, 4), new Vector3(0, 0, 0), 'exclude');
+const inheritedD = createClipBox(new Vector3(3, 3, 3), new Vector3(-3, 0, 0)); // inherits CLIP_OUTSIDE
+
+pco.material.setClipBoxes([includeA, excludeB, inheritedD]);
 ```
 
- - `ClipMode.DISABLED` – no clipping.
- - `ClipMode.CLIP_OUTSIDE` – only points inside the box are rendered.
- - `ClipMode.CLIP_INSIDE` – only points outside the box are rendered.
- - `ClipMode.HIGHLIGHT_INSIDE` – all points rendered; points inside the box are highlighted.
-
 ## Clip Spheres
- - Clip spheres restrict the rendered region of a point cloud to a sphere-shaped volume.
- - Use the `createClipSphere(center, radius)` helper to build an `IClipSphere` from a center position and radius.
- - Set clip spheres with `setClipSpheres()`.
- - Optional per-volume mode: `mode?: "include" | "exclude"`.
- - Clip boxes and clip spheres can be used together; a point is considered "inside" if it falls inside any box or any sphere.
+ - Clip spheres work like clip boxes and support the same optional mode.
+ - Use `createClipSphere(center, radius, mode?)` to build an `IClipSphere`.
+ - `mode?: "include" | "exclude"`.
+ - If `mode` is `undefined`, the sphere inherits the global material `clipMode`.
+
+## Clip Planes
+ - Clip planes do not have per-plane mode; they always use inherited global mode behavior.
+ - Planes are represented by `P = insideAllPlanes` in the visibility formulas above.
 
 ```javascript
 import { ClipMode, createClipSphere } from 'potree-core';
 import { Vector3 } from 'three';
 
-// Create a sphere of radius 3 centered at world position (0, 1, 0)
-const clipSphere = createClipSphere(new Vector3(0, 1, 0), 3);
-
-// Highlight points inside the sphere (other modes: CLIP_OUTSIDE, CLIP_INSIDE, DISABLED)
 pco.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
-pco.material.setClipSpheres([clipSphere]);
+
+const sphereA = createClipSphere(new Vector3(0, 1, 0), 3, 'exclude');
+const sphereB = createClipSphere(new Vector3(5, 1, 0), 2); // inherits HIGHLIGHT_INSIDE
+
+pco.material.setClipSpheres([sphereA, sphereB]);
 ```
-
-```javascript
-import { createClipBox } from 'potree-core';
-import { Vector3 } from 'three';
-
-// Include outer region A and exclude inner region B (hole in A)
-const includeA = {
-  ...createClipBox(new Vector3(10, 10, 10), new Vector3(0, 0, 0)),
-  mode: 'include',
-};
-
-const excludeB = {
-  ...createClipBox(new Vector3(4, 4, 4), new Vector3(0, 0, 0)),
-  mode: 'exclude',
-};
-
-pco.material.setClipBoxes([includeA, excludeB]);
-```
-
- - `ClipMode.DISABLED` - no clipping.
- - `ClipMode.CLIP_OUTSIDE` - only points inside the sphere are rendered.
- - `ClipMode.CLIP_INSIDE` - only points outside the sphere are rendered.
- - `ClipMode.HIGHLIGHT_INSIDE` - all points rendered; points inside the sphere are highlighted.
 ## Custom Request Manager
    - The potree core library uses a custom request manager to handle the loading of point cloud data.
    - The request manager can be replaced by a custom implementation, for example to use a custom caching system or to handle requests in a different way.
@@ -179,3 +166,4 @@ pco.material.setClipBoxes([includeA, excludeB]);
  ### To Do
  - Supports logarithmic depth buffer (just by enabling it on the threejs renderer), useful for large scale visualization.
  - Point clouds are automatically updated, frustum culling is used to avoid unnecessary updates (better update performance for multiple point clouds).
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ loop();
 ## Clip Boxes
  - Clip boxes restrict the rendered region of a point cloud to a box-shaped volume.
  - Use the `createClipBox(size, position)` helper to build an `IClipBox` from a size and world-space position.
- - Set the desired `ClipMode` on the material and pass the clip boxes to `setClipBoxes()`.
+ - Set clip boxes on the material with `setClipBoxes()`.
+ - Optional per-volume mode: `mode?: "include" | "exclude"`.
+   - `include` keeps points inside the volume.
+   - `exclude` removes points inside the volume.
+ - Legacy behavior remains unchanged when no clip volume has `mode` set.
 
 ```javascript
 import { ClipMode, createClipBox } from 'potree-core';
@@ -86,7 +90,8 @@ pco.material.setClipBoxes([clipBox]);
 ## Clip Spheres
  - Clip spheres restrict the rendered region of a point cloud to a sphere-shaped volume.
  - Use the `createClipSphere(center, radius)` helper to build an `IClipSphere` from a center position and radius.
- - Set the desired `ClipMode` on the material and pass the clip spheres to `setClipSpheres()`.
+ - Set clip spheres with `setClipSpheres()`.
+ - Optional per-volume mode: `mode?: "include" | "exclude"`.
  - Clip boxes and clip spheres can be used together; a point is considered "inside" if it falls inside any box or any sphere.
 
 ```javascript
@@ -101,11 +106,28 @@ pco.material.clipMode = ClipMode.HIGHLIGHT_INSIDE;
 pco.material.setClipSpheres([clipSphere]);
 ```
 
- - `ClipMode.DISABLED` – no clipping.
- - `ClipMode.CLIP_OUTSIDE` – only points inside the sphere are rendered.
- - `ClipMode.CLIP_INSIDE` – only points outside the sphere are rendered.
- - `ClipMode.HIGHLIGHT_INSIDE` – all points rendered; points inside the sphere are highlighted.
+```javascript
+import { createClipBox } from 'potree-core';
+import { Vector3 } from 'three';
 
+// Include outer region A and exclude inner region B (hole in A)
+const includeA = {
+  ...createClipBox(new Vector3(10, 10, 10), new Vector3(0, 0, 0)),
+  mode: 'include',
+};
+
+const excludeB = {
+  ...createClipBox(new Vector3(4, 4, 4), new Vector3(0, 0, 0)),
+  mode: 'exclude',
+};
+
+pco.material.setClipBoxes([includeA, excludeB]);
+```
+
+ - `ClipMode.DISABLED` - no clipping.
+ - `ClipMode.CLIP_OUTSIDE` - only points inside the sphere are rendered.
+ - `ClipMode.CLIP_INSIDE` - only points outside the sphere are rendered.
+ - `ClipMode.HIGHLIGHT_INSIDE` - all points rendered; points inside the sphere are highlighted.
 ## Custom Request Manager
    - The potree core library uses a custom request manager to handle the loading of point cloud data.
    - The request manager can be replaced by a custom implementation, for example to use a custom caching system or to handle requests in a different way.

--- a/README.md
+++ b/README.md
@@ -166,4 +166,3 @@ pco.material.setClipSpheres([sphereA, sphereB]);
  ### To Do
  - Supports logarithmic depth buffer (just by enabling it on the threejs renderer), useful for large scale visualization.
  - Point clouds are automatically updated, frustum culling is used to avoid unnecessary updates (better update performance for multiple point clouds).
-

--- a/example/main.ts
+++ b/example/main.ts
@@ -116,8 +116,8 @@ document.body.onload = function () {
 		edlRadius: 1.4,
 		// Clipping
 		clipMode: 'Highlight Inside',
-		pumpClipBox1Enabled: true,
-		pumpClipBox2Enabled: true,
+		pumpClipBox1Enabled: false,
+		pumpClipBox2Enabled: false,
 		pumpClipBox1Mode: 'Include',
 		pumpClipBox2Mode: 'Exclude',
 		// Points

--- a/example/main.ts
+++ b/example/main.ts
@@ -37,6 +37,13 @@ document.body.onload = function () {
 	clipHelperY.raycast = () => false;
 	clipHelperZ.raycast = () => false;
 
+	let pumpClipBox1Size: Vector3 | null = null;
+	let pumpClipBox1Center: Vector3 | null = null;
+	let pumpClipBox2Size: Vector3 | null = null;
+	let pumpClipBox2Center: Vector3 | null = null;
+	let pumpClipBox1Helper: Mesh | null = null;
+	let pumpClipBox2Helper: Mesh | null = null;
+
 	function updateClipPlanes() {
 		if (!clipPlanesTarget) return;
 		const planes: Plane[] = [];
@@ -59,10 +66,30 @@ document.body.onload = function () {
 		updateClipPlanes();
 	}
 
-	function updatePumpClipBoxModes() {
+	function updatePumpClipBoxes() {
 		if (!pumpClipBoxesTarget) return;
-		pumpClipBoxesTarget.material.setClipBoxMode(0, clipVolumeModeMap[params.pumpClipBox1Mode]);
-		pumpClipBoxesTarget.material.setClipBoxMode(1, clipVolumeModeMap[params.pumpClipBox2Mode]);
+		if (!pumpClipBox1Size || !pumpClipBox1Center || !pumpClipBox2Size || !pumpClipBox2Center) return;
+
+		const clipBoxes = [];
+		if (params.pumpClipBox1Enabled) {
+			clipBoxes.push(createClipBox(
+				pumpClipBox1Size,
+				pumpClipBox1Center,
+				clipVolumeModeMap[params.pumpClipBox1Mode],
+			));
+		}
+		if (params.pumpClipBox2Enabled) {
+			clipBoxes.push(createClipBox(
+				pumpClipBox2Size,
+				pumpClipBox2Center,
+				clipVolumeModeMap[params.pumpClipBox2Mode],
+			));
+		}
+
+		pumpClipBoxesTarget.material.setClipBoxes(clipBoxes);
+
+		if (pumpClipBox1Helper) pumpClipBox1Helper.visible = params.pumpClipBox1Enabled;
+		if (pumpClipBox2Helper) pumpClipBox2Helper.visible = params.pumpClipBox2Enabled;
 	}
 
 	// ClipMode
@@ -89,8 +116,10 @@ document.body.onload = function () {
 		edlRadius: 1.4,
 		// Clipping
 		clipMode: 'Highlight Inside',
-		pumpClipBox1Mode: 'Inherit Global',
-		pumpClipBox2Mode: 'Inherit Global',
+		pumpClipBox1Enabled: true,
+		pumpClipBox2Enabled: true,
+		pumpClipBox1Mode: 'Include',
+		pumpClipBox2Mode: 'Exclude',
 		// Points
 		pointSize: 1.0,
 		sizeType: 'Adaptive',
@@ -223,11 +252,21 @@ document.body.onload = function () {
 	};
 
 	// Load point clouds: lion and pump
-	loadPointCloud('/data/lion_takanawa/', 'cloud.js', new Vector3(-10, -2, 5), new Euler(-Math.PI / 2, 0, 0), undefined, false, true, false);
-	loadPointCloud('/data/lion_takanawa/', 'cloud.js', new Vector3(0, -2, 10), new Euler(-Math.PI / 2, 0, 0), undefined, true, false, false);
-	loadPointCloud('/data/pump/', 'metadata.json', new Vector3(0, -1.5, 3), new Euler(-Math.PI / 2, 0, 0), new Vector3(2, 2, 2), true, false, true);
+	loadPointCloud('/data/lion_takanawa/', 'cloud.js', new Vector3(-10, -2, 5), new Euler(-Math.PI / 2, 0, 0), undefined, false, true, false, false);
+	loadPointCloud('/data/lion_takanawa/', 'cloud.js', new Vector3(0, -2, 10), new Euler(-Math.PI / 2, 0, 0), undefined, true, false, false, false);
+	loadPointCloud('/data/pump/', 'metadata.json', new Vector3(0, -1.5, 3), new Euler(-Math.PI / 2, 0, 0), new Vector3(2, 2, 2), true, false, true, true);
 
-	function loadPointCloud(baseUrl: string, url: string, position?: Vector3, rotation?: Euler, scale?: Vector3, applyClipBox = false, applyClipSphere = false, applyClipPlanes = false) {
+	function loadPointCloud(
+		baseUrl: string,
+		url: string,
+		position?: Vector3,
+		rotation?: Euler,
+		scale?: Vector3,
+		applyClipBox = false,
+		applyClipSphere = false,
+		applyClipPlanes = false,
+		usePumpClipBoxes = false,
+	) {
 		potree.loadPointCloud(url, baseUrl).then(function (pco: PointCloudOctree) {
 			const sizeTypeMap: Record<string, PointSizeType> = {
 				'Fixed': PointSizeType.FIXED,
@@ -274,35 +313,49 @@ document.body.onload = function () {
 			pco.material.clipMode = clipModeMap[params.clipMode];
 
 			if (applyClipBox) {
-				// ClipBoxes
-				pumpClipBoxesTarget = pco;
+				if (usePumpClipBoxes) {
+					// Pump clip boxes with per-volume mode controls.
+					pumpClipBoxesTarget = pco;
 
-				const primaryClipBoxSize = worldSize.clone().multiplyScalar(0.35);
-				const secondaryClipBoxSize = worldSize.clone().multiplyScalar(0.25);
-				const secondaryClipBoxCenter = center.clone().add(new Vector3(
-					worldSize.x * 0.18,
-					worldSize.y * 0.08,
-					-worldSize.z * 0.12,
-				));
+					pumpClipBox1Size = worldSize.clone().multiplyScalar(0.35);
+					pumpClipBox1Center = center.clone();
+					pumpClipBox2Size = worldSize.clone().multiplyScalar(0.25);
+					pumpClipBox2Center = center.clone().add(new Vector3(
+						worldSize.x * 0.18,
+						worldSize.y * 0.08,
+						-worldSize.z * 0.12,
+					));
 
-				pco.material.setClipBoxes([
-					createClipBox(primaryClipBoxSize, center),
-					createClipBox(secondaryClipBoxSize, secondaryClipBoxCenter),
-				]);
-				updatePumpClipBoxModes();
+					updatePumpClipBoxes();
 
-				const addClipBoxHelper = (size: Vector3, position: Vector3, color: number) => {
+					const addClipBoxHelper = (size: Vector3, position: Vector3, color: number) => {
+						const clipBoxHelper = new Mesh(
+							new BoxGeometry(size.x, size.y, size.z),
+							new MeshBasicMaterial({ color, wireframe: true }),
+						);
+						clipBoxHelper.position.copy(position);
+						clipBoxHelper.raycast = () => false;
+						scene.add(clipBoxHelper);
+						return clipBoxHelper;
+					};
+
+					pumpClipBox1Helper = addClipBoxHelper(pumpClipBox1Size, pumpClipBox1Center, 0x0066FF);
+					pumpClipBox2Helper = addClipBoxHelper(pumpClipBox2Size, pumpClipBox2Center, 0x00B894);
+					updatePumpClipBoxes();
+				} else {
+					// Default single clip box used by the lion example.
+					const halfSize = worldSize.clone().multiplyScalar(0.5);
+					const clipBox = createClipBox(halfSize, center);
+					pco.material.setClipBoxes([clipBox]);
+
 					const clipBoxHelper = new Mesh(
-						new BoxGeometry(size.x, size.y, size.z),
-						new MeshBasicMaterial({ color, wireframe: true }),
+						new BoxGeometry(halfSize.x, halfSize.y, halfSize.z),
+						new MeshBasicMaterial({ color: 0x0066FF, wireframe: true }),
 					);
-					clipBoxHelper.position.copy(position);
+					clipBoxHelper.position.copy(center);
 					clipBoxHelper.raycast = () => false;
 					scene.add(clipBoxHelper);
-				};
-
-				addClipBoxHelper(primaryClipBoxSize, center, 0x0066FF);
-				addClipBoxHelper(secondaryClipBoxSize, secondaryClipBoxCenter, 0x00B894);
+				}
 			}
 
 			if (applyClipPlanes) {
@@ -394,12 +447,18 @@ document.body.onload = function () {
 		for (const pco of pointClouds) pco.material.clipMode = mode;
 	});
 
-	const pumpClipBoxesFolder = clipFolder.addFolder('Pump Clip Boxes');
+	const pumpClipBoxesFolder = clipFolder.addFolder('Clipping Boxes with Individual Modes');
+	pumpClipBoxesFolder.add(params, 'pumpClipBox1Enabled').name('Box 1 Enabled').onChange(() => {
+		updatePumpClipBoxes();
+	});
 	pumpClipBoxesFolder.add(params, 'pumpClipBox1Mode', Object.keys(clipVolumeModeMap)).name('Box 1 Mode').onChange(() => {
-		updatePumpClipBoxModes();
+		updatePumpClipBoxes();
+	});
+	pumpClipBoxesFolder.add(params, 'pumpClipBox2Enabled').name('Box 2 Enabled').onChange(() => {
+		updatePumpClipBoxes();
 	});
 	pumpClipBoxesFolder.add(params, 'pumpClipBox2Mode', Object.keys(clipVolumeModeMap)).name('Box 2 Mode').onChange(() => {
-		updatePumpClipBoxModes();
+		updatePumpClipBoxes();
 	});
 
 	// Clip Plane sub-folder

--- a/example/main.ts
+++ b/example/main.ts
@@ -448,18 +448,10 @@ document.body.onload = function () {
 	});
 
 	const pumpClipBoxesFolder = clipFolder.addFolder('Clipping Boxes with Individual Modes');
-	pumpClipBoxesFolder.add(params, 'pumpClipBox1Enabled').name('Box 1 Enabled').onChange(() => {
-		updatePumpClipBoxes();
-	});
-	pumpClipBoxesFolder.add(params, 'pumpClipBox1Mode', Object.keys(clipVolumeModeMap)).name('Box 1 Mode').onChange(() => {
-		updatePumpClipBoxes();
-	});
-	pumpClipBoxesFolder.add(params, 'pumpClipBox2Enabled').name('Box 2 Enabled').onChange(() => {
-		updatePumpClipBoxes();
-	});
-	pumpClipBoxesFolder.add(params, 'pumpClipBox2Mode', Object.keys(clipVolumeModeMap)).name('Box 2 Mode').onChange(() => {
-		updatePumpClipBoxes();
-	});
+	pumpClipBoxesFolder.add(params, 'pumpClipBox1Enabled').name('Box 1 Enabled').onChange(updatePumpClipBoxes);
+	pumpClipBoxesFolder.add(params, 'pumpClipBox1Mode', Object.keys(clipVolumeModeMap)).name('Box 1 Mode').onChange(updatePumpClipBoxes);
+	pumpClipBoxesFolder.add(params, 'pumpClipBox2Enabled').name('Box 2 Enabled').onChange(updatePumpClipBoxes);
+	pumpClipBoxesFolder.add(params, 'pumpClipBox2Mode', Object.keys(clipVolumeModeMap)).name('Box 2 Mode').onChange(updatePumpClipBoxes);
 
 	// Clip Plane sub-folder
 	const planeFolder = clipFolder.addFolder('Clip Planes');

--- a/example/main.ts
+++ b/example/main.ts
@@ -3,12 +3,13 @@ import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
 import { TransformControls } from 'three/examples/jsm/controls/TransformControls';
 import { ViewHelper } from 'three/examples/jsm/helpers/ViewHelper';
 import { GUI } from 'three/examples/jsm/libs/lil-gui.module.min.js';
-import { ClipMode, PointCloudOctree, PointSizeType, Potree, PotreeRenderer, createClipBox, createClipSphere } from '../source';
+import { ClipMode, ClipVolumeMode, PointCloudOctree, PointSizeType, Potree, PotreeRenderer, createClipBox, createClipSphere } from '../source';
 
 document.body.onload = function () {
 	const potree = new Potree();
 	let pointClouds: PointCloudOctree[] = [];
 	let clipPlanesTarget: PointCloudOctree | null = null;
+	let pumpClipBoxesTarget: PointCloudOctree | null = null;
 
 	// Clip plane state
 	const clipPlaneX = new Plane(new Vector3(1, 0, 0), 0);
@@ -58,12 +59,24 @@ document.body.onload = function () {
 		updateClipPlanes();
 	}
 
+	function updatePumpClipBoxModes() {
+		if (!pumpClipBoxesTarget) return;
+		pumpClipBoxesTarget.material.setClipBoxMode(0, clipVolumeModeMap[params.pumpClipBox1Mode]);
+		pumpClipBoxesTarget.material.setClipBoxMode(1, clipVolumeModeMap[params.pumpClipBox2Mode]);
+	}
+
 	// ClipMode
 	const clipModeMap: Record<string, ClipMode> = {
 		'Disabled': ClipMode.DISABLED,
 		'Highlight Inside': ClipMode.HIGHLIGHT_INSIDE,
 		'Clip Outside': ClipMode.CLIP_OUTSIDE,
 		'Clip Inside': ClipMode.CLIP_INSIDE,
+	};
+
+	const clipVolumeModeMap: Record<string, ClipVolumeMode | undefined> = {
+		'Inherit Global': undefined,
+		'Include': 'include',
+		'Exclude': 'exclude',
 	};
 
 	// State
@@ -76,6 +89,8 @@ document.body.onload = function () {
 		edlRadius: 1.4,
 		// Clipping
 		clipMode: 'Highlight Inside',
+		pumpClipBox1Mode: 'Inherit Global',
+		pumpClipBox2Mode: 'Inherit Global',
 		// Points
 		pointSize: 1.0,
 		sizeType: 'Adaptive',
@@ -259,19 +274,35 @@ document.body.onload = function () {
 			pco.material.clipMode = clipModeMap[params.clipMode];
 
 			if (applyClipBox) {
-				// ClipBox
-				const halfSize = worldSize.clone().multiplyScalar(0.5);
-				const clipBox = createClipBox(halfSize, center);
-				pco.material.setClipBoxes([clipBox]);
+				// ClipBoxes
+				pumpClipBoxesTarget = pco;
 
-				const clipBoxHelper = new Mesh(
-					new BoxGeometry(halfSize.x, halfSize.y, halfSize.z),
-					new MeshBasicMaterial({ color: 0x0066FF, wireframe: true }),
-				);
-				clipBoxHelper.position.copy(center);
-				clipBoxHelper.raycast = () => false;
-				scene.add(clipBoxHelper);
+				const primaryClipBoxSize = worldSize.clone().multiplyScalar(0.35);
+				const secondaryClipBoxSize = worldSize.clone().multiplyScalar(0.25);
+				const secondaryClipBoxCenter = center.clone().add(new Vector3(
+					worldSize.x * 0.18,
+					worldSize.y * 0.08,
+					-worldSize.z * 0.12,
+				));
 
+				pco.material.setClipBoxes([
+					createClipBox(primaryClipBoxSize, center),
+					createClipBox(secondaryClipBoxSize, secondaryClipBoxCenter),
+				]);
+				updatePumpClipBoxModes();
+
+				const addClipBoxHelper = (size: Vector3, position: Vector3, color: number) => {
+					const clipBoxHelper = new Mesh(
+						new BoxGeometry(size.x, size.y, size.z),
+						new MeshBasicMaterial({ color, wireframe: true }),
+					);
+					clipBoxHelper.position.copy(position);
+					clipBoxHelper.raycast = () => false;
+					scene.add(clipBoxHelper);
+				};
+
+				addClipBoxHelper(primaryClipBoxSize, center, 0x0066FF);
+				addClipBoxHelper(secondaryClipBoxSize, secondaryClipBoxCenter, 0x00B894);
 			}
 
 			if (applyClipPlanes) {
@@ -361,6 +392,14 @@ document.body.onload = function () {
 	clipFolder.add(params, 'clipMode', Object.keys(clipModeMap)).name('Clip Mode').onChange((v: string) => {
 		const mode = clipModeMap[v];
 		for (const pco of pointClouds) pco.material.clipMode = mode;
+	});
+
+	const pumpClipBoxesFolder = clipFolder.addFolder('Pump Clip Boxes');
+	pumpClipBoxesFolder.add(params, 'pumpClipBox1Mode', Object.keys(clipVolumeModeMap)).name('Box 1 Mode').onChange(() => {
+		updatePumpClipBoxModes();
+	});
+	pumpClipBoxesFolder.add(params, 'pumpClipBox2Mode', Object.keys(clipVolumeModeMap)).name('Box 2 Mode').onChange(() => {
+		updatePumpClipBoxModes();
 	});
 
 	// Clip Plane sub-folder

--- a/source/materials/clipping.ts
+++ b/source/materials/clipping.ts
@@ -13,12 +13,18 @@ export interface IClipSphere {
  *
  * @param center - The center position of the clip sphere in world space. Defaults to the origin.
  * @param radius - The radius of the clip sphere.
+ * @param mode - Optional per-volume mode (`include` or `exclude`). Defaults to undefined (inherit global mode).
  * @returns An IClipSphere object ready to be passed to PointCloudMaterial.setClipSpheres().
  */
-export function createClipSphere(center: Vector3 = new Vector3(0, 0, 0), radius: number): IClipSphere {
+export function createClipSphere(
+  center: Vector3 = new Vector3(0, 0, 0),
+  radius: number,
+  mode?: ClipVolumeMode,
+): IClipSphere {
   return {
     center: center.clone(),
     radius,
+    mode,
   };
 }
 
@@ -46,9 +52,14 @@ export interface IClipBox {
  *
  * @param size - The dimensions of the clip box.
  * @param position - The center position of the clip box in world space. Defaults to the origin.
+ * @param mode - Optional per-volume mode (`include` or `exclude`). Defaults to undefined (inherit global mode).
  * @returns An IClipBox object ready to be passed to PointCloudMaterial.setClipBoxes().
  */
-export function createClipBox(size: Vector3, position: Vector3 = new Vector3(0, 0, 0)): IClipBox {
+export function createClipBox(
+  size: Vector3,
+  position: Vector3 = new Vector3(0, 0, 0),
+  mode?: ClipVolumeMode,
+): IClipBox {
   const box = new Box3(new Vector3(-0.5, -0.5, -0.5), new Vector3(0.5, 0.5, 0.5));
 
   const scaleMatrix = new Matrix4().makeScale(size.x, size.y, size.z);
@@ -61,5 +72,6 @@ export function createClipBox(size: Vector3, position: Vector3 = new Vector3(0, 
     matrix,
     inverse,
     position: position.clone(),
+    mode,
   };
 }

--- a/source/materials/clipping.ts
+++ b/source/materials/clipping.ts
@@ -1,8 +1,11 @@
 import {Box3, Matrix4, Vector3} from 'three';
 
+export type ClipVolumeMode = 'include' | 'exclude';
+
 export interface IClipSphere {
   center: Vector3;
   radius: number;
+  mode?: ClipVolumeMode;
 }
 
 /**
@@ -31,6 +34,7 @@ export interface IClipBox {
   inverse: Matrix4;
   matrix: Matrix4;
   position: Vector3;
+  mode?: ClipVolumeMode;
 }
 
 /**

--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -99,10 +99,14 @@ export interface IPointCloudMaterialUniforms {
 	clipBoxCount: IUniform<number>;
 	/** Array containing clipping box parameters */
 	clipBoxes: IUniform<Float32Array>;
+	/** Array containing clipping box modes (0 = include, 1 = exclude) */
+	clipBoxModes: IUniform<Float32Array>;
 	/** Number of active clipping spheres */
 	clipSphereCount: IUniform<number>;
 	/** Array containing clipping sphere parameters (vec4: xyz=center, w=radius) */
 	clipSpheres: IUniform<Float32Array>;
+	/** Array containing clipping sphere modes (0 = include, 1 = exclude) */
+	clipSphereModes: IUniform<Float32Array>;
 	/** Number of active clipping planes */
 	clipPlaneCount: IUniform<number>;
 	/** Array containing clipping plane parameters (vec4: xyz=normal, w=constant) */
@@ -271,6 +275,8 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
 	clipSpheres: IClipSphere[] = [];
 
+	private hasPerClipVolumeModes: boolean = false;
+
 	private numClipPlanes: number = 0;
 
 	visibleNodesTexture: Texture | undefined;
@@ -294,8 +300,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		classificationLUT: makeUniform('t', this.classificationTexture || new Texture()),
 		clipBoxCount: makeUniform('f', 0),
 		clipBoxes: makeUniform('Matrix4fv', [] as any),
+		clipBoxModes: makeUniform('fv', [] as any),
 		clipSphereCount: makeUniform('f', 0),
 		clipSpheres: makeUniform('fv', [] as any),
+		clipSphereModes: makeUniform('fv', [] as any),
 		clipPlaneCount: makeUniform('f', 0),
 		clipPlanes: makeUniform('fv', [] as any),
 		depthMap: makeUniform('t', null),
@@ -621,6 +629,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
 			define('use_clip_plane');
 		}
 
+		if (this.hasPerClipVolumeModes) {
+			define('clip_per_volume_mode');
+		}
+
 		if (this.highlightPoint) {
 			define('highlight_point');
 		}
@@ -643,22 +655,23 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		return parts.join('\n');
 	}
 
+	private recomputeHasPerClipVolumeModes(): boolean {
+		return this.clipBoxes.some((box) => box.mode !== undefined) ||
+			this.clipSpheres.some((sphere) => sphere.mode !== undefined);
+	}
+
 	setClipBoxes(clipBoxes: IClipBox[]): void {
 		if (!clipBoxes) {
 			return;
 		}
 
-		this.clipBoxes = clipBoxes;
+		const hadClipBoxes = this.numClipBoxes > 0;
+		const hadPerClipVolumeModes = this.hasPerClipVolumeModes;
 
-		const doUpdate =
-			this.numClipBoxes !== clipBoxes.length && (clipBoxes.length === 0 || this.numClipBoxes === 0);
+		this.clipBoxes = clipBoxes;
 
 		this.numClipBoxes = clipBoxes.length;
 		this.setUniform('clipBoxCount', this.numClipBoxes);
-
-		if (doUpdate) {
-			this.updateShaderSource();
-		}
 
 		const clipBoxesLength = this.numClipBoxes * 16;
 		const clipBoxesArray = new Float32Array(clipBoxesLength);
@@ -674,6 +687,21 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		}
 
 		this.setUniform('clipBoxes', clipBoxesArray);
+
+		const clipBoxModesArray = new Float32Array(this.numClipBoxes);
+		for (let i = 0; i < this.numClipBoxes; i++) {
+			clipBoxModesArray[i] = this.clipBoxes[i].mode === 'exclude' ? 1 : 0;
+		}
+		this.setUniform('clipBoxModes', clipBoxModesArray);
+
+		this.hasPerClipVolumeModes = this.recomputeHasPerClipVolumeModes();
+
+		const hasClipBoxes = this.numClipBoxes > 0;
+		const doUpdate = hadClipBoxes !== hasClipBoxes ||
+			hadPerClipVolumeModes !== this.hasPerClipVolumeModes;
+		if (doUpdate) {
+			this.updateShaderSource();
+		}
 	}
 
 	setClipSpheres(clipSpheres: IClipSphere[]): void {
@@ -681,17 +709,13 @@ export class PointCloudMaterial extends RawShaderMaterial {
 			return;
 		}
 
-		this.clipSpheres = clipSpheres;
+		const hadClipSpheres = this.numClipSpheres > 0;
+		const hadPerClipVolumeModes = this.hasPerClipVolumeModes;
 
-		const doUpdate =
-			(this.numClipSpheres === 0) !== (clipSpheres.length === 0);
+		this.clipSpheres = clipSpheres;
 
 		this.numClipSpheres = clipSpheres.length;
 		this.setUniform('clipSphereCount', this.numClipSpheres);
-
-		if (doUpdate) {
-			this.updateShaderSource();
-		}
 
 		const clipSpheresLength = this.numClipSpheres * 4;
 		const clipSpheresArray = new Float32Array(clipSpheresLength);
@@ -704,6 +728,21 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		}
 
 		this.setUniform('clipSpheres', clipSpheresArray);
+
+		const clipSphereModesArray = new Float32Array(this.numClipSpheres);
+		for (let i = 0; i < this.numClipSpheres; i++) {
+			clipSphereModesArray[i] = this.clipSpheres[i].mode === 'exclude' ? 1 : 0;
+		}
+		this.setUniform('clipSphereModes', clipSphereModesArray);
+
+		this.hasPerClipVolumeModes = this.recomputeHasPerClipVolumeModes();
+
+		const hasClipSpheres = this.numClipSpheres > 0;
+		const doUpdate = hadClipSpheres !== hasClipSpheres ||
+			hadPerClipVolumeModes !== this.hasPerClipVolumeModes;
+		if (doUpdate) {
+			this.updateShaderSource();
+		}
 	}
 
 	/**

--- a/source/materials/point-cloud-material.ts
+++ b/source/materials/point-cloud-material.ts
@@ -32,7 +32,7 @@ import { PointCloudOctree } from '../point-cloud-octree';
 import { PointCloudOctreeNode } from '../point-cloud-octree-node';
 import { byLevelAndIndex } from '../utils/utils';
 import { DEFAULT_CLASSIFICATION } from './classification';
-import { ClipMode, IClipBox, IClipSphere } from './clipping';
+import { ClipMode, ClipVolumeMode, IClipBox, IClipSphere } from './clipping';
 import { PointColorType, PointOpacityType, PointShape, PointSizeType, TreeType } from './enums';
 import { SPECTRAL } from './gradients';
 import {
@@ -99,13 +99,13 @@ export interface IPointCloudMaterialUniforms {
 	clipBoxCount: IUniform<number>;
 	/** Array containing clipping box parameters */
 	clipBoxes: IUniform<Float32Array>;
-	/** Array containing clipping box modes (0 = include, 1 = exclude) */
+	/** Array containing clipping box modes (0 = include, 1 = exclude, 2 = inherit global mode) */
 	clipBoxModes: IUniform<Float32Array>;
 	/** Number of active clipping spheres */
 	clipSphereCount: IUniform<number>;
 	/** Array containing clipping sphere parameters (vec4: xyz=center, w=radius) */
 	clipSpheres: IUniform<Float32Array>;
-	/** Array containing clipping sphere modes (0 = include, 1 = exclude) */
+	/** Array containing clipping sphere modes (0 = include, 1 = exclude, 2 = inherit global mode) */
 	clipSphereModes: IUniform<Float32Array>;
 	/** Number of active clipping planes */
 	clipPlaneCount: IUniform<number>;
@@ -261,6 +261,10 @@ const OUTPUT_COLOR_ENCODING = {
 };
 
 export class PointCloudMaterial extends RawShaderMaterial {
+	private static readonly CLIP_VOLUME_MODE_INCLUDE = 0;
+	private static readonly CLIP_VOLUME_MODE_EXCLUDE = 1;
+	private static readonly CLIP_VOLUME_MODE_INHERIT = 2;
+
 	private static helperVec3 = new Vector3();
 
 	lights = false;
@@ -274,8 +278,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
 	numClipSpheres: number = 0;
 
 	clipSpheres: IClipSphere[] = [];
-
-	private hasPerClipVolumeModes: boolean = false;
 
 	private numClipPlanes: number = 0;
 
@@ -629,10 +631,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
 			define('use_clip_plane');
 		}
 
-		if (this.hasPerClipVolumeModes) {
-			define('clip_per_volume_mode');
-		}
-
 		if (this.highlightPoint) {
 			define('highlight_point');
 		}
@@ -655,9 +653,30 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		return parts.join('\n');
 	}
 
-	private recomputeHasPerClipVolumeModes(): boolean {
-		return this.clipBoxes.some((box) => box.mode !== undefined) ||
-			this.clipSpheres.some((sphere) => sphere.mode !== undefined);
+	private static encodeClipVolumeMode(mode: ClipVolumeMode | undefined): number {
+		if (mode === undefined) {
+			return PointCloudMaterial.CLIP_VOLUME_MODE_INHERIT;
+		}
+		if (mode === 'exclude') {
+			return PointCloudMaterial.CLIP_VOLUME_MODE_EXCLUDE;
+		}
+		return PointCloudMaterial.CLIP_VOLUME_MODE_INCLUDE;
+	}
+
+	private updateClipBoxModesUniform(): void {
+		const clipBoxModesArray = new Float32Array(this.numClipBoxes);
+		for (let i = 0; i < this.numClipBoxes; i++) {
+			clipBoxModesArray[i] = PointCloudMaterial.encodeClipVolumeMode(this.clipBoxes[i].mode);
+		}
+		this.setUniform('clipBoxModes', clipBoxModesArray);
+	}
+
+	private updateClipSphereModesUniform(): void {
+		const clipSphereModesArray = new Float32Array(this.numClipSpheres);
+		for (let i = 0; i < this.numClipSpheres; i++) {
+			clipSphereModesArray[i] = PointCloudMaterial.encodeClipVolumeMode(this.clipSpheres[i].mode);
+		}
+		this.setUniform('clipSphereModes', clipSphereModesArray);
 	}
 
 	setClipBoxes(clipBoxes: IClipBox[]): void {
@@ -666,8 +685,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		}
 
 		const hadClipBoxes = this.numClipBoxes > 0;
-		const hadPerClipVolumeModes = this.hasPerClipVolumeModes;
-
 		this.clipBoxes = clipBoxes;
 
 		this.numClipBoxes = clipBoxes.length;
@@ -688,17 +705,10 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
 		this.setUniform('clipBoxes', clipBoxesArray);
 
-		const clipBoxModesArray = new Float32Array(this.numClipBoxes);
-		for (let i = 0; i < this.numClipBoxes; i++) {
-			clipBoxModesArray[i] = this.clipBoxes[i].mode === 'exclude' ? 1 : 0;
-		}
-		this.setUniform('clipBoxModes', clipBoxModesArray);
-
-		this.hasPerClipVolumeModes = this.recomputeHasPerClipVolumeModes();
+		this.updateClipBoxModesUniform();
 
 		const hasClipBoxes = this.numClipBoxes > 0;
-		const doUpdate = hadClipBoxes !== hasClipBoxes ||
-			hadPerClipVolumeModes !== this.hasPerClipVolumeModes;
+		const doUpdate = hadClipBoxes !== hasClipBoxes;
 		if (doUpdate) {
 			this.updateShaderSource();
 		}
@@ -710,8 +720,6 @@ export class PointCloudMaterial extends RawShaderMaterial {
 		}
 
 		const hadClipSpheres = this.numClipSpheres > 0;
-		const hadPerClipVolumeModes = this.hasPerClipVolumeModes;
-
 		this.clipSpheres = clipSpheres;
 
 		this.numClipSpheres = clipSpheres.length;
@@ -729,20 +737,37 @@ export class PointCloudMaterial extends RawShaderMaterial {
 
 		this.setUniform('clipSpheres', clipSpheresArray);
 
-		const clipSphereModesArray = new Float32Array(this.numClipSpheres);
-		for (let i = 0; i < this.numClipSpheres; i++) {
-			clipSphereModesArray[i] = this.clipSpheres[i].mode === 'exclude' ? 1 : 0;
-		}
-		this.setUniform('clipSphereModes', clipSphereModesArray);
-
-		this.hasPerClipVolumeModes = this.recomputeHasPerClipVolumeModes();
+		this.updateClipSphereModesUniform();
 
 		const hasClipSpheres = this.numClipSpheres > 0;
-		const doUpdate = hadClipSpheres !== hasClipSpheres ||
-			hadPerClipVolumeModes !== this.hasPerClipVolumeModes;
+		const doUpdate = hadClipSpheres !== hasClipSpheres;
 		if (doUpdate) {
 			this.updateShaderSource();
 		}
+	}
+
+	setClipBoxMode(index: number, mode?: ClipVolumeMode): void {
+		if (index < 0 || index >= this.clipBoxes.length) {
+			return;
+		}
+		if (this.clipBoxes[index].mode === mode) {
+			return;
+		}
+
+		this.clipBoxes[index].mode = mode;
+		this.updateClipBoxModesUniform();
+	}
+
+	setClipSphereMode(index: number, mode?: ClipVolumeMode): void {
+		if (index < 0 || index >= this.clipSpheres.length) {
+			return;
+		}
+		if (this.clipSpheres[index].mode === mode) {
+			return;
+		}
+
+		this.clipSpheres[index].mode = mode;
+		this.updateClipSphereModesUniform();
 	}
 
 	/**

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -478,7 +478,10 @@ void main() {
 			bool insideAnyInclude = false;
 			bool insideAnyExclude = false;
 			bool insideAnyHighlight = false;
-			bool hasShapeVolumes = clipBoxCount > 0.0 || clipSphereCount > 0.0;
+			bool hasShapeVolumes = clipBoxCount > 0.0;
+			#if defined use_clip_sphere
+				hasShapeVolumes = hasShapeVolumes || clipSphereCount > 0.0;
+			#endif
 
 			float inheritedMode = global_clip_mode_include;
 			#if defined clip_outside

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -559,9 +559,11 @@ void main() {
 				visible = (hasShapeVolumes && baseVisible) || !insideAllPlanes;
 			#elif defined clip_highlight_inside
 				visible = baseVisible;
-				if (!hasShapeVolumes && clipPlaneCount > 0.0 && insideAllPlanes) {
-					insideAnyHighlight = true;
-				}
+				#if defined use_clip_plane
+					if (!hasShapeVolumes && clipPlaneCount > 0.0 && insideAllPlanes) {
+						insideAnyHighlight = true;
+					}
+				#endif
 			#endif
 
 			if (!visible) { gl_Position = vec4(1000.0); }

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -5,6 +5,14 @@ precision highp int;
 #define max_clip_spheres 30 // Maximum number of clipping spheres
 #define max_clip_planes 30  // Maximum number of clipping planes
 
+#define clip_volume_mode_include 0.0
+#define clip_volume_mode_exclude 1.0
+#define clip_volume_mode_inherit 2.0
+
+#define global_clip_mode_include 0.0
+#define global_clip_mode_exclude 1.0
+#define global_clip_mode_highlight 2.0
+
 // Input Attributes
 in vec3 position;
 in vec3 normal;
@@ -37,12 +45,12 @@ uniform float orthoHeight;
 
 #if defined use_clip_box
 	uniform mat4 clipBoxes[max_clip_boxes]; // Clipping box transforms
-	uniform float clipBoxModes[max_clip_boxes]; // 0 = include, 1 = exclude
+	uniform float clipBoxModes[max_clip_boxes]; // 0 = include, 1 = exclude, 2 = inherit global mode
 #endif
 
 #if defined use_clip_sphere
 	uniform vec4 clipSpheres[max_clip_spheres]; // Clipping spheres: xyz = center, w = radius
-	uniform float clipSphereModes[max_clip_spheres]; // 0 = include, 1 = exclude
+	uniform float clipSphereModes[max_clip_spheres]; // 0 = include, 1 = exclude, 2 = inherit global mode
 	uniform float clipSphereCount;
 #endif
 
@@ -465,102 +473,97 @@ void main() {
 
 	// CLIPPING
 	#if defined use_clip_box || defined use_clip_sphere || defined use_clip_plane
-		#if defined clip_per_volume_mode
-			#if !defined(clip_disabled)
-				bool hasIncludeVolumes = false;
-				bool insideAnyInclude = false;
-				bool insideAnyExclude = false;
+		#if !defined(clip_disabled)
+			bool hasIncludeVolumes = false;
+			bool insideAnyInclude = false;
+			bool insideAnyExclude = false;
+			bool insideAnyHighlight = false;
+			bool hasShapeVolumes = clipBoxCount > 0.0 || clipSphereCount > 0.0;
 
-				#if defined use_clip_box
-					for (int i = 0; i < max_clip_boxes; i++) {
-						if (i == int(clipBoxCount)) break;
-						vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
-						bool inside = abs(clipPosition.x) <= 0.5
-							&& abs(clipPosition.y) <= 0.5
-							&& abs(clipPosition.z) <= 0.5;
-						bool isExclude = clipBoxModes[i] > 0.5;
-						if (isExclude) {
-							insideAnyExclude = insideAnyExclude || inside;
-						} else {
-							hasIncludeVolumes = true;
-							insideAnyInclude = insideAnyInclude || inside;
-						}
-					}
-				#endif
-
-				#if defined use_clip_sphere
-					vec4 modelPos = modelMatrix * vec4(position, 1.0);
-					for (int i = 0; i < max_clip_spheres; i++) {
-						if (i == int(clipSphereCount)) break;
-						float dist = distance(modelPos.xyz, clipSpheres[i].xyz);
-						bool inside = dist <= clipSpheres[i].w;
-						bool isExclude = clipSphereModes[i] > 0.5;
-						if (isExclude) {
-							insideAnyExclude = insideAnyExclude || inside;
-						} else {
-							hasIncludeVolumes = true;
-							insideAnyInclude = insideAnyInclude || inside;
-						}
-					}
-				#endif
-
-				bool visible = (!hasIncludeVolumes || insideAnyInclude) && !insideAnyExclude;
-				if (!visible) { gl_Position = vec4(1000.0); }
-
-				#if defined clip_highlight_inside
-					if (insideAnyInclude) { vColor.r += 0.5; }
-				#endif
+			float inheritedMode = global_clip_mode_include;
+			#if defined clip_outside
+				inheritedMode = global_clip_mode_include;
+			#elif defined clip_inside
+				inheritedMode = global_clip_mode_exclude;
+			#elif defined clip_highlight_inside
+				inheritedMode = global_clip_mode_highlight;
 			#endif
-		#else
-			bool insideAny = false;
-			bool hasVolumeClip = false;
+
+			bool insideAllPlanes = true;
+			#if defined use_clip_plane
+				if (clipPlaneCount > 0.0) {
+					vec4 clipWorldPos = modelMatrix * vec4(position, 1.0);
+					for (int i = 0; i < max_clip_planes; i++) {
+						if (i == int(clipPlaneCount)) break;
+						float d = dot(clipPlanes[i].xyz, clipWorldPos.xyz) + clipPlanes[i].w;
+						if (d < 0.0) { insideAllPlanes = false; break; }
+					}
+				}
+			#endif
 
 			#if defined use_clip_box
-				hasVolumeClip = true;
 				for (int i = 0; i < max_clip_boxes; i++) {
 					if (i == int(clipBoxCount)) break;
 					vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
-					bool inside = abs(clipPosition.x) <= 0.5 && abs(clipPosition.y) <= 0.5 && abs(clipPosition.z) <= 0.5;
-					insideAny = insideAny || inside;
+					bool inside = abs(clipPosition.x) <= 0.5
+						&& abs(clipPosition.y) <= 0.5
+						&& abs(clipPosition.z) <= 0.5;
+					float mode = clipBoxModes[i];
+					if (mode == clip_volume_mode_inherit) {
+						if (inheritedMode == global_clip_mode_highlight) {
+							insideAnyHighlight = insideAnyHighlight || (inside && insideAllPlanes);
+							continue;
+						}
+						mode = inheritedMode;
+					}
+					if (mode == clip_volume_mode_exclude) {
+						insideAnyExclude = insideAnyExclude || inside;
+					} else {
+						hasIncludeVolumes = true;
+						insideAnyInclude = insideAnyInclude || inside;
+					}
 				}
 			#endif
 
 			#if defined use_clip_sphere
-				hasVolumeClip = true;
 				vec4 modelPos = modelMatrix * vec4(position, 1.0);
 				for (int i = 0; i < max_clip_spheres; i++) {
 					if (i == int(clipSphereCount)) break;
 					float dist = distance(modelPos.xyz, clipSpheres[i].xyz);
-					insideAny = insideAny || (dist <= clipSpheres[i].w);
+					bool inside = dist <= clipSpheres[i].w;
+					float mode = clipSphereModes[i];
+					if (mode == clip_volume_mode_inherit) {
+						if (inheritedMode == global_clip_mode_highlight) {
+							insideAnyHighlight = insideAnyHighlight || (inside && insideAllPlanes);
+							continue;
+						}
+						mode = inheritedMode;
+					}
+					if (mode == clip_volume_mode_exclude) {
+						insideAnyExclude = insideAnyExclude || inside;
+					} else {
+						hasIncludeVolumes = true;
+						insideAnyInclude = insideAnyInclude || inside;
+					}
 				}
 			#endif
 
-			// When only clip planes are used, start as inside
-			if (!hasVolumeClip) insideAny = true;
-
-			#if defined use_clip_plane
-				// Point must be on positive side of all planes
-				vec4 clipWorldPos = modelMatrix * vec4(position, 1.0);
-				for (int i = 0; i < max_clip_planes; i++) {
-					if (i == int(clipPlaneCount)) break;
-					float d = dot(clipPlanes[i].xyz, clipWorldPos.xyz) + clipPlanes[i].w;
-					// Even if a point was accepted by a volume clip,
-					// it is rejected when it falls on the negative side of a plane.
-					if (d < 0.0) { insideAny = false; break; }
-				}
-			#endif
-			
+			bool baseVisible = (!hasIncludeVolumes || insideAnyInclude) && !insideAnyExclude;
+			bool visible = baseVisible;
 			#if defined clip_outside
-				if (!insideAny) { gl_Position = vec4(1000.0); } // Cull if outside any clip volume
+				visible = baseVisible && insideAllPlanes;
 			#elif defined clip_inside
-				if (insideAny) { gl_Position = vec4(1000.0); } // Cull if inside any clip volume
-			#elif defined clip_highlight_inside && !defined(color_type_depth)
-				if (!insideAny) { /* additional processing if needed */ }
+				visible = (hasShapeVolumes && baseVisible) || !insideAllPlanes;
+			#elif defined clip_highlight_inside
+				visible = baseVisible;
+				if (!hasShapeVolumes && clipPlaneCount > 0.0 && insideAllPlanes) {
+					insideAnyHighlight = true;
+				}
 			#endif
 
-			#if defined clip_highlight_inside
-				if (insideAny) { vColor.r += 0.5; }
-			#endif
+			if (!visible) { gl_Position = vec4(1000.0); }
+
+			if (insideAnyHighlight) { vColor.r += 0.5; }
 		#endif
 	#endif
 

--- a/source/materials/shaders/pointcloud.vs
+++ b/source/materials/shaders/pointcloud.vs
@@ -37,10 +37,12 @@ uniform float orthoHeight;
 
 #if defined use_clip_box
 	uniform mat4 clipBoxes[max_clip_boxes]; // Clipping box transforms
+	uniform float clipBoxModes[max_clip_boxes]; // 0 = include, 1 = exclude
 #endif
 
 #if defined use_clip_sphere
 	uniform vec4 clipSpheres[max_clip_spheres]; // Clipping spheres: xyz = center, w = radius
+	uniform float clipSphereModes[max_clip_spheres]; // 0 = include, 1 = exclude
 	uniform float clipSphereCount;
 #endif
 
@@ -463,54 +465,102 @@ void main() {
 
 	// CLIPPING
 	#if defined use_clip_box || defined use_clip_sphere || defined use_clip_plane
-		bool insideAny = false;
-		bool hasVolumeClip = false;
+		#if defined clip_per_volume_mode
+			#if !defined(clip_disabled)
+				bool hasIncludeVolumes = false;
+				bool insideAnyInclude = false;
+				bool insideAnyExclude = false;
 
-		#if defined use_clip_box
-			hasVolumeClip = true;
-			for (int i = 0; i < max_clip_boxes; i++) {
-				if (i == int(clipBoxCount)) break;
-				vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
-				bool inside = abs(clipPosition.x) <= 0.5 && abs(clipPosition.y) <= 0.5 && abs(clipPosition.z) <= 0.5;
-				insideAny = insideAny || inside;
-			}
-		#endif
+				#if defined use_clip_box
+					for (int i = 0; i < max_clip_boxes; i++) {
+						if (i == int(clipBoxCount)) break;
+						vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
+						bool inside = abs(clipPosition.x) <= 0.5
+							&& abs(clipPosition.y) <= 0.5
+							&& abs(clipPosition.z) <= 0.5;
+						bool isExclude = clipBoxModes[i] > 0.5;
+						if (isExclude) {
+							insideAnyExclude = insideAnyExclude || inside;
+						} else {
+							hasIncludeVolumes = true;
+							insideAnyInclude = insideAnyInclude || inside;
+						}
+					}
+				#endif
 
-		#if defined use_clip_sphere
-			hasVolumeClip = true;
-			vec4 modelPos = modelMatrix * vec4(position, 1.0);
-			for (int i = 0; i < max_clip_spheres; i++) {
-				if (i == int(clipSphereCount)) break;
-				float dist = distance(modelPos.xyz, clipSpheres[i].xyz);
-				insideAny = insideAny || (dist <= clipSpheres[i].w);
-			}
-		#endif
+				#if defined use_clip_sphere
+					vec4 modelPos = modelMatrix * vec4(position, 1.0);
+					for (int i = 0; i < max_clip_spheres; i++) {
+						if (i == int(clipSphereCount)) break;
+						float dist = distance(modelPos.xyz, clipSpheres[i].xyz);
+						bool inside = dist <= clipSpheres[i].w;
+						bool isExclude = clipSphereModes[i] > 0.5;
+						if (isExclude) {
+							insideAnyExclude = insideAnyExclude || inside;
+						} else {
+							hasIncludeVolumes = true;
+							insideAnyInclude = insideAnyInclude || inside;
+						}
+					}
+				#endif
 
-		// When only clip planes are used, start as inside
-		if (!hasVolumeClip) insideAny = true;
+				bool visible = (!hasIncludeVolumes || insideAnyInclude) && !insideAnyExclude;
+				if (!visible) { gl_Position = vec4(1000.0); }
 
-		#if defined use_clip_plane
-			// Point must be on positive side of all planes
-			vec4 clipWorldPos = modelMatrix * vec4(position, 1.0);
-			for (int i = 0; i < max_clip_planes; i++) {
-				if (i == int(clipPlaneCount)) break;
-				float d = dot(clipPlanes[i].xyz, clipWorldPos.xyz) + clipPlanes[i].w;
-				// Even if a point was accepted by a volume clip,
-				// it is rejected when it falls on the negative side of a plane.
-				if (d < 0.0) { insideAny = false; break; }
-			}
-		#endif
-		
-		#if defined clip_outside
-			if (!insideAny) { gl_Position = vec4(1000.0); } // Cull if outside any clip volume
-		#elif defined clip_inside
-			if (insideAny) { gl_Position = vec4(1000.0); } // Cull if inside any clip volume
-		#elif defined clip_highlight_inside && !defined(color_type_depth)
-			if (!insideAny) { /* additional processing if needed */ }
-		#endif
+				#if defined clip_highlight_inside
+					if (insideAnyInclude) { vColor.r += 0.5; }
+				#endif
+			#endif
+		#else
+			bool insideAny = false;
+			bool hasVolumeClip = false;
 
-		#if defined clip_highlight_inside
-			if (insideAny) { vColor.r += 0.5; }
+			#if defined use_clip_box
+				hasVolumeClip = true;
+				for (int i = 0; i < max_clip_boxes; i++) {
+					if (i == int(clipBoxCount)) break;
+					vec4 clipPosition = clipBoxes[i] * modelMatrix * vec4(position, 1.0);
+					bool inside = abs(clipPosition.x) <= 0.5 && abs(clipPosition.y) <= 0.5 && abs(clipPosition.z) <= 0.5;
+					insideAny = insideAny || inside;
+				}
+			#endif
+
+			#if defined use_clip_sphere
+				hasVolumeClip = true;
+				vec4 modelPos = modelMatrix * vec4(position, 1.0);
+				for (int i = 0; i < max_clip_spheres; i++) {
+					if (i == int(clipSphereCount)) break;
+					float dist = distance(modelPos.xyz, clipSpheres[i].xyz);
+					insideAny = insideAny || (dist <= clipSpheres[i].w);
+				}
+			#endif
+
+			// When only clip planes are used, start as inside
+			if (!hasVolumeClip) insideAny = true;
+
+			#if defined use_clip_plane
+				// Point must be on positive side of all planes
+				vec4 clipWorldPos = modelMatrix * vec4(position, 1.0);
+				for (int i = 0; i < max_clip_planes; i++) {
+					if (i == int(clipPlaneCount)) break;
+					float d = dot(clipPlanes[i].xyz, clipWorldPos.xyz) + clipPlanes[i].w;
+					// Even if a point was accepted by a volume clip,
+					// it is rejected when it falls on the negative side of a plane.
+					if (d < 0.0) { insideAny = false; break; }
+				}
+			#endif
+			
+			#if defined clip_outside
+				if (!insideAny) { gl_Position = vec4(1000.0); } // Cull if outside any clip volume
+			#elif defined clip_inside
+				if (insideAny) { gl_Position = vec4(1000.0); } // Cull if inside any clip volume
+			#elif defined clip_highlight_inside && !defined(color_type_depth)
+				if (!insideAny) { /* additional processing if needed */ }
+			#endif
+
+			#if defined clip_highlight_inside
+				if (insideAny) { vColor.r += 0.5; }
+			#endif
 		#endif
 	#endif
 

--- a/source/point-cloud-octree-picker.ts
+++ b/source/point-cloud-octree-picker.ts
@@ -310,13 +310,28 @@ export class PointCloudOctreePicker
 		if (params.pickOutsideClipRegion) 
 		{
 			pickMaterial.clipMode = ClipMode.DISABLED;
+			pickMaterial.setClipBoxes([]);
+			pickMaterial.setClipSpheres([]);
 		}
 		else 
 		{
 			pickMaterial.clipMode = nodeMaterial.clipMode;
-			pickMaterial.setClipBoxes(
-				nodeMaterial.clipMode === ClipMode.CLIP_OUTSIDE ? nodeMaterial.clipBoxes : [],
-			);
+			const hasPerClipVolumeModes =
+				nodeMaterial.clipBoxes.some((box) => box.mode !== undefined) ||
+				nodeMaterial.clipSpheres.some((sphere) => sphere.mode !== undefined);
+
+			if (hasPerClipVolumeModes) 
+			{
+				pickMaterial.setClipBoxes(nodeMaterial.clipBoxes);
+				pickMaterial.setClipSpheres(nodeMaterial.clipSpheres);
+			}
+			else 
+			{
+				pickMaterial.setClipBoxes(
+					nodeMaterial.clipMode === ClipMode.CLIP_OUTSIDE ? nodeMaterial.clipBoxes : [],
+				);
+				pickMaterial.setClipSpheres([]);
+			}
 		}
 	}
 

--- a/source/point-cloud-octree-picker.ts
+++ b/source/point-cloud-octree-picker.ts
@@ -312,26 +312,14 @@ export class PointCloudOctreePicker
 			pickMaterial.clipMode = ClipMode.DISABLED;
 			pickMaterial.setClipBoxes([]);
 			pickMaterial.setClipSpheres([]);
+			pickMaterial.clippingPlanes = [];
 		}
 		else 
 		{
 			pickMaterial.clipMode = nodeMaterial.clipMode;
-			const hasPerClipVolumeModes =
-				nodeMaterial.clipBoxes.some((box) => box.mode !== undefined) ||
-				nodeMaterial.clipSpheres.some((sphere) => sphere.mode !== undefined);
-
-			if (hasPerClipVolumeModes) 
-			{
-				pickMaterial.setClipBoxes(nodeMaterial.clipBoxes);
-				pickMaterial.setClipSpheres(nodeMaterial.clipSpheres);
-			}
-			else 
-			{
-				pickMaterial.setClipBoxes(
-					nodeMaterial.clipMode === ClipMode.CLIP_OUTSIDE ? nodeMaterial.clipBoxes : [],
-				);
-				pickMaterial.setClipSpheres([]);
-			}
+			pickMaterial.setClipBoxes(nodeMaterial.clipBoxes);
+			pickMaterial.setClipSpheres(nodeMaterial.clipSpheres);
+			pickMaterial.clippingPlanes = nodeMaterial.clippingPlanes;
 		}
 	}
 

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -373,20 +373,36 @@ export class Potree implements IPotree
 	private shouldClip(pointCloud: PointCloudOctree, boundingBox: Box3): boolean 
 	{
 		const material = pointCloud.material;
-		const hasPerClipVolumeModes =
-			material.clipBoxes.some((box) => box.mode !== undefined) ||
-			material.clipSpheres.some((sphere) => sphere.mode !== undefined);
-
-		// Mixed include/exclude semantics are not safely handled by this coarse culling path.
-		// Keep legacy fast culling for CLIP_OUTSIDE only when no per-volume modes are active.
-		if (hasPerClipVolumeModes) 
+		if (material.clipMode === ClipMode.DISABLED) 
 		{
 			return false;
 		}
 
-		if (material.numClipBoxes === 0 || material.clipMode !== ClipMode.CLIP_OUTSIDE) 
+		const hasClipPlanes = !!(material.clippingPlanes && material.clippingPlanes.length > 0);
+		if (material.numClipBoxes === 0 || material.numClipSpheres > 0 || hasClipPlanes) 
 		{
 			return false;
+		}
+
+		const isEffectiveInclude = (mode: 'include' | 'exclude' | undefined): boolean => 
+		{
+			if (mode !== undefined) 
+			{
+				return mode === 'include';
+			}
+			if (material.clipMode === ClipMode.CLIP_INSIDE) 
+			{
+				return false;
+			}
+			return material.clipMode === ClipMode.CLIP_OUTSIDE;
+		};
+
+		for (let i = 0; i < material.clipBoxes.length; i++) 
+		{
+			if (!isEffectiveInclude(material.clipBoxes[i].mode)) 
+			{
+				return false;
+			}
 		}
 
 		const box2 = boundingBox.clone();

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -370,36 +370,36 @@ export class Potree implements IPotree
 		}
 	}
 
-	private shouldClip(pointCloud: PointCloudOctree, boundingBox: Box3): boolean 
+	private shouldClip(pointCloud: PointCloudOctree, boundingBox: Box3): boolean
 	{
 		const material = pointCloud.material;
-		if (material.clipMode === ClipMode.DISABLED) 
+		if (material.clipMode === ClipMode.DISABLED)
 		{
 			return false;
 		}
 
 		const hasClipPlanes = !!(material.clippingPlanes && material.clippingPlanes.length > 0);
-		if (material.numClipBoxes === 0 || material.numClipSpheres > 0 || hasClipPlanes) 
+		if (material.numClipBoxes === 0 || material.numClipSpheres > 0 || hasClipPlanes)
 		{
 			return false;
 		}
 
-		const isEffectiveInclude = (mode: 'include' | 'exclude' | undefined): boolean => 
+		const isEffectiveInclude = (mode: 'include' | 'exclude' | undefined): boolean =>
 		{
-			if (mode !== undefined) 
+			if (mode !== undefined)
 			{
 				return mode === 'include';
 			}
-			if (material.clipMode === ClipMode.CLIP_INSIDE) 
+			if (material.clipMode === ClipMode.CLIP_INSIDE)
 			{
 				return false;
 			}
 			return material.clipMode === ClipMode.CLIP_OUTSIDE;
 		};
 
-		for (let i = 0; i < material.clipBoxes.length; i++) 
+		for (let i = 0; i < material.clipBoxes.length; i++)
 		{
-			if (!isEffectiveInclude(material.clipBoxes[i].mode)) 
+			if (!isEffectiveInclude(material.clipBoxes[i].mode))
 			{
 				return false;
 			}

--- a/source/potree.ts
+++ b/source/potree.ts
@@ -373,6 +373,16 @@ export class Potree implements IPotree
 	private shouldClip(pointCloud: PointCloudOctree, boundingBox: Box3): boolean 
 	{
 		const material = pointCloud.material;
+		const hasPerClipVolumeModes =
+			material.clipBoxes.some((box) => box.mode !== undefined) ||
+			material.clipSpheres.some((sphere) => sphere.mode !== undefined);
+
+		// Mixed include/exclude semantics are not safely handled by this coarse culling path.
+		// Keep legacy fast culling for CLIP_OUTSIDE only when no per-volume modes are active.
+		if (hasPerClipVolumeModes) 
+		{
+			return false;
+		}
 
 		if (material.numClipBoxes === 0 || material.clipMode !== ClipMode.CLIP_OUTSIDE) 
 		{
@@ -471,4 +481,3 @@ export class Potree implements IPotree
 		};
 	})();
 }
-


### PR DESCRIPTION
## Description

Adds per-volume clipping modes for clip boxes and clip spheres.

Since potree only supports a global clipping mode and we needed modes, per volume in our project, we added optional modes per volume, with inherited global behavior and unified clipping evaluation that supports mixed include/exclude setups while preserving existing global clipping behavior.

## What Changed
- Extended the clipping API:
  - `IClipBox.mode?: "include" | "exclude"`
  - `IClipSphere.mode?: "include" | "exclude"`
  - `createClipBox(..., mode?)` / `createClipSphere(..., mode?)`
- Added per-volume mode uniforms in `PointCloudMaterial`:
  - `clipBoxModes`, `clipSphereModes` (`include`, `exclude`, `inherit`)
- Added mode update helpers in material:
  - `setClipBoxMode(index, mode?)`
  - `setClipSphereMode(index, mode?)`
- Reworked vertex shader clipping logic into one unified flow:
  - base visibility rule for combining boxes/spheres with different per-volume modes:
   - `B = (!hasIncludeVolumes || insideAnyInclude) && !insideAnyExclude`
  - plane integration:
   - `P = insideAllPlanes`, `S = hasBoxOrSphere`
   - when global mode is `CLIP_OUTSIDE`: `visible = B && P`
   - when global mode is `CLIP_INSIDE`: `visible = (S && B) || !P`
- Kept `ClipMode.DISABLED` as global off switch
- Updated README docs to describe mode inheritance and clipping formulas.
- Updated Example to include new clipping capabilites.

## Compatibility Notes
- If `mode` is `undefined`, that volume inherits global `clipMode`.
- Global `HIGHLIGHT_INSIDE` still works via inherited mode (`undefined`) and highlights without changing visibility.
- Existing global clipping behavior remains consistent when all effective volume modes are not set or align with global mode.

## Design Considerations
- `ClipMode.DISABLED` remains a single global off switch, so the global mode must be set to a non-disabled value for per-volume include/exclude behavior to take effect. This could be redesigned so per-volume modes always override the global mode, but that would remove a single centralized off switch.
- Per-volume highlighting can currently be achieved using global `HIGHLIGHT_INSIDE` and specifying the modes for the volumes that should not be highlighted. An alternative would be to also add explicit per-volume `highlight` mode.

Disclaimer: We used AI in the development of this feature, but followed it up with extensive testing and code review.